### PR TITLE
Migrate project workflow to central reusable workflow

### DIFF
--- a/.github/workflows/add-to-personal-project.yml
+++ b/.github/workflows/add-to-personal-project.yml
@@ -1,0 +1,13 @@
+name: Trigger Add to Personal Project
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+  pull_request_target:
+    types: [labeled, unlabeled]
+
+jobs:
+  add-to-personal-project:
+    uses: markheydon/github-workflows/.github/workflows/add-to-personal-project.yml@main
+    secrets:
+      PERSONAL_ACCESS_TOKEN: ${ secrets.PERSONAL_ACCESS_TOKEN }


### PR DESCRIPTION
Adds/updates .github/workflows/add-to-personal-project.yml to call markheydon/github-workflows/.github/workflows/add-to-personal-project.yml@main, and removes legacy project workflow files.