### PR TITLE
Add Blazor sample workbench for SDK testing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,12 +41,23 @@ FreeAgent.NET is an open-source, modern .NET SDK for the FreeAgent REST API. It 
 - Interfaces: I prefix.
 - Test classes: [ClassName]Tests.
 
+## Sample and Test App Sync
+
+The Blazor sample (`samples/FreeAgent.Client.Sample`) must reflect the **current, implemented** state of the SDK — not planned or aspirational endpoints.
+
+- Every API endpoint implemented in `src/FreeAgent.Client/Services/` must have a corresponding page or component in the sample app that exercises it.
+- When a new service or endpoint is added to the SDK, a matching UI page in the sample app must be added in the same PR.
+- When an endpoint is removed or renamed, the sample app must be updated in the same PR.
+- Do not add sample UI for endpoints that do not yet exist in the SDK.
+- The sample app is the living reference for "what this SDK can do today". Keep it honest.
+
 ## What Not to Do
 
 - Do not put business logic in controllers.
 - Do not generate migrations automatically - flag when a migration is needed.
 - Do not add NuGet packages without flagging it first.
 - Do not change the architecture pattern without an ADR.
+- Do not add sample app pages for SDK endpoints that are not yet implemented.
 
 ## GitHub Issues
 

--- a/.github/instructions/blazor-csharp-mh.instructions.md
+++ b/.github/instructions/blazor-csharp-mh.instructions.md
@@ -1,0 +1,88 @@
+---
+description: 'Unified guidance for Blazor and C# work in Blazor projects, designed to coexist with task-specific skills.'
+applyTo: '**/*.razor, **/*.razor.cs, **/*.razor.css, **/*.cs'
+---
+
+# Blazor + C# Unified Instructions
+
+Use this file as baseline guidance for Blazor projects that include Razor UI and C# code.
+
+## Intent
+
+- Keep behaviour predictable, maintainable, and aligned with repository conventions.
+- Prefer minimal, focused changes for the requested outcome.
+- Avoid guidance that conflicts with specialized skills; defer to them when active.
+
+## Scope and Change Discipline
+
+- Follow repository conventions first.
+- Keep changes small and scoped to the user request.
+- Reuse existing abstractions before introducing new ones.
+- Do not change SDK, target framework, project architecture, or generated files unless explicitly requested.
+
+## C# Version and Language Features
+
+- Use modern C# features that are supported by the repository's target framework and SDK.
+- Do not force or set a newer language version than the project supports unless explicitly requested.
+- If language-version support is unclear, prefer the project defaults.
+
+## C# Design and Reliability
+
+- Use clear naming and least required visibility.
+- Validate inputs at boundaries and throw precise exceptions.
+- Prefer async end-to-end for I/O work.
+- Avoid blocking async calls such as `.Result`, `.Wait()`, and `.GetAwaiter().GetResult()`.
+- Propagate `CancellationToken` when long-running or cancellable work is involved.
+
+## Comments and Documentation
+
+- Prefer self-documenting code and comments that explain intent or trade-offs.
+- Avoid boilerplate comments that restate obvious code.
+- For public APIs, include XML docs (`<summary>`, and when relevant `<param>`, `<returns>`, `<exception>`, `<example>`).
+- For internal/private methods, add comments only when behaviour is non-obvious.
+
+## Blazor Component Patterns
+
+- Keep components focused and small.
+- Keep UI logic lightweight in `.razor`; move complex logic to `.razor.cs` or services.
+- Use `EventCallback` or `EventCallback<T>` for child-to-parent communication.
+- Prefer explicit parameters over hidden coupling.
+- Use lifecycle methods intentionally (`OnInitializedAsync`, `OnParametersSetAsync`) and avoid fire-and-forget tasks.
+
+## MudBlazor Usage (When MudBlazor Is Present)
+
+- Prefer MudBlazor components and parameters before custom CSS.
+- Prefer composition with MudBlazor layout primitives and utility classes.
+- Keep custom `.razor.css` minimal and use it only when component options are insufficient.
+- Ensure required providers are present in the main layout when using dialogs/popovers/snackbars.
+
+## Fluent UI Blazor Usage (When Fluent UI Blazor Is Present)
+
+- Prefer Fluent UI Blazor components and their parameters before custom CSS.
+- Prefer composition with Fluent UI layout primitives such as `FluentStack`, `FluentGrid`, `FluentGridItem`, and `FluentSpacer`.
+- Keep custom `.razor.css` minimal and use it only when component options are insufficient.
+- Ensure required providers are present in the main layout: `FluentDesignTheme`, `FluentDialogProvider`, `FluentToastProvider`, `FluentTooltipProvider`, and `FluentMessageBarProvider`.
+
+## Testing Guidance
+
+- Use the testing framework already used in the repository.
+- Add or update tests for changed behaviour, especially public-facing behaviour.
+- Keep tests deterministic and independent.
+- Follow existing naming conventions in the repository instead of imposing a global pattern.
+- Mock only external dependencies when isolation is necessary.
+
+## Security and Observability
+
+- Treat external input as untrusted and validate/sanitise as needed.
+- Avoid logging secrets or sensitive data.
+- Preserve existing logging and telemetry patterns in the repository.
+
+## Decision Priority
+
+When guidance conflicts, apply this order:
+
+1. User request
+2. Repository conventions
+3. Active task-specific skill (for example: MudBlazor, Fluent UI Blazor, async, docs, or test-framework skills)
+4. This instruction file
+5. General Blazor/.NET defaults

--- a/.github/skills/mudblazor-mh/SKILL.md
+++ b/.github/skills/mudblazor-mh/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: mudblazor-mh
+description: Guide for using the MudBlazor component library in Blazor applications. Use this when building or refactoring Blazor pages and components with MudBlazor. Covers setup, layout, component usage patterns, dialog and snackbar services, data grids, forms, colour pickers, theming, and optional bUnit examples. Also use when troubleshooting z-index, popup rendering, or styling issues.
+---
+
+# MudBlazor - Consumer Usage Guide
+
+**MudBlazor** is a Material Design component library for Blazor built entirely in pure C#/Razor with no web components or shadow DOM.
+
+**Version scope:** Written for modern MudBlazor projects on .NET 8+ Blazor with interactive rendering.
+
+**Official docs:** https://mudblazor.com/  
+**Component demos:** https://mudblazor.com/components/
+
+---
+
+## Decision Order
+
+When building or refactoring UI with MudBlazor, make decisions in this order:
+
+1. Use an existing MudBlazor component and its parameters.
+2. Compose MudBlazor layout primitives such as `MudStack`, `MudGrid`, `MudItem`, `MudPaper`, `MudContainer`, and `MudSpacer`.
+3. Apply MudBlazor utility classes in the component `Class` attribute for spacing, alignment, display, and sizing.
+4. Use theme configuration or built-in component properties such as `Color`, `Variant`, `Typo`, `Elevation`, `Dense`, and `GutterSize`.
+5. Only then consider isolated `.razor.css`, and only when the requirement cannot be achieved by the options above.
+
+Custom CSS is an exception, not a normal implementation tool. Raw HTML should be limited to framework-owned host elements or cases where MudBlazor genuinely has no suitable equivalent.
+
+---
+
+## Setup
+
+### NuGet Package
+
+```xml
+<PackageReference Include="MudBlazor" />
+```
+
+If your repository uses Central Package Management, define or update the `MudBlazor` version in `Directory.Packages.props` via `<PackageVersion Include="MudBlazor" Version="..." />`.
+
+### Program.cs
+
+```csharp
+builder.Services.AddMudServices();
+// Or with configuration:
+builder.Services.AddMudServices(config =>
+{
+    config.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.BottomRight;
+    config.SnackbarConfiguration.PreventDuplicates = false;
+});
+```
+
+### _Imports.razor
+
+```razor
+@using MudBlazor
+```
+
+### MainLayout.razor - Required Providers
+
+The following components **MUST** appear in `MainLayout.razor` for services to work:
+
+```razor
+<MudThemeProvider />
+<MudPopoverProvider />   <!-- required for dropdowns, autocomplete, select -->
+<MudDialogProvider />
+<MudSnackbarProvider />
+```
+
+Without `MudPopoverProvider`, popup components (autocomplete, select) will render nothing.
+
+---
+
+## Layout Structure
+
+Use the official MudBlazor template shape as a starting point:
+
+```razor
+<MudLayout>
+    <MudAppBar Elevation="1">
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
+                       Edge="Edge.Start" OnClick="@ToggleDrawer" />
+        <MudText Typo="Typo.h6">Application</MudText>
+        <MudSpacer />
+    </MudAppBar>
+
+    <MudDrawer @bind-Open="_drawerOpen" Elevation="2" ClipMode="DrawerClipMode.Always">
+        <MudNavMenu>
+            <MudNavLink Href="/" Match="NavLinkMatch.All"
+                        Icon="@Icons.Material.Filled.Dashboard">Dashboard</MudNavLink>
+            <MudNavLink Href="/items" Icon="@Icons.Material.Filled.Inventory2">Items</MudNavLink>
+            <MudNavLink Href="/settings"
+                        Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
+        </MudNavMenu>
+    </MudDrawer>
+
+    <MudMainContent Class="pt-16 pa-4">
+        @Body
+    </MudMainContent>
+</MudLayout>
+```
+
+Use page-level `MudContainer`, `MudPaper`, `MudStack`, and `MudGrid` composition inside `@Body` rather than reworking `MainLayout` with bespoke wrappers or CSS.
+
+## Styling Guidance
+
+- Prefer component parameters and composition over styling.
+- Prefer MudBlazor utility classes such as `pa-4`, `pt-16`, `mt-4`, `d-flex`, `justify-end`, and `align-center` before writing CSS.
+- Prefer `MudStack` or `MudGrid` over raw `<div>` elements used only for layout.
+- Prefer `MudText`, `MudAlert`, `MudChip`, `MudPaper`, and `MudDivider` over styled HTML elements.
+- Do not add `<style>` blocks to Razor files.
+- Only create or extend `.razor.css` when the requirement cannot be met through components, parameters, theme settings, or utility classes. Keep the CSS isolated and minimal.
+
+---
+
+## Component Quick Reference
+
+See [references/COMPONENT-CHOOSER.md](references/COMPONENT-CHOOSER.md) for the full mapping.
+
+### Reference Map
+
+Use these references after the chooser points you to a component family:
+
+- [references/INPUTS.md](./references/INPUTS.md) for text, selection, picker, upload, and validation-oriented input components.
+- [references/BUTTONS.md](./references/BUTTONS.md) for action components, grouped actions, floating actions, and icon toggle actions.
+- [references/LAYOUT-NAVIGATION.md](./references/LAYOUT-NAVIGATION.md) for shell structure, responsive layout, menus, and navigation components.
+- [references/DATA-DISPLAY.md](./references/DATA-DISPLAY.md) for tabular, list, timeline, tree, card, and media display components.
+- [references/FEEDBACK-OVERLAYS.md](./references/FEEDBACK-OVERLAYS.md) for alerts, progress, dialogs, snackbars, overlays, and placeholders.
+- [references/DATAGRID.md](./references/DATAGRID.md) for detailed `MudDataGrid<T>` usage patterns.
+- [references/KNOWN-PITFALLS.md](./references/KNOWN-PITFALLS.md) for operational troubleshooting.
+- [references/THEMING.md](./references/THEMING.md) for palette and typography customisation.
+- [references/BUNIT.md](./references/BUNIT.md) for component testing patterns when bUnit is already in use.
+
+### Text Input
+
+```razor
+<MudTextField @bind-Value="_value" Label="Name" Variant="Variant.Outlined" />
+<MudTextField @bind-Value="_search" Label="Search" Adornment="Adornment.End"
+              AdornmentIcon="@Icons.Material.Filled.Search" />
+<MudTextField @bind-Value="_multi" Label="Description" Lines="4" />
+```
+
+### Select
+
+```razor
+<MudSelect @bind-Value="_selected" Label="Category" Variant="Variant.Outlined">
+    @foreach (var option in _options)
+    {
+        <MudSelectItem Value="@option">@option.Name</MudSelectItem>
+    }
+</MudSelect>
+```
+
+### Autocomplete (multi-select)
+
+```razor
+<MudAutocomplete T="string" Label="Items" @bind-Value="_item"
+                 SearchFunc="@SearchItems" Variant="Variant.Outlined" />
+```
+
+### Checkbox
+
+```razor
+<MudCheckBox @bind-Value="_checked" Label="Apply to all items" />
+```
+
+### Button
+
+```razor
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@Save">Save</MudButton>
+<MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="@Cancel">Cancel</MudButton>
+<MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="@Delete" />
+```
+
+### Colour Picker
+
+```razor
+<MudColorPicker @bind-Text="_colour" Label="Accent colour"
+                ColorPickerMode="ColorPickerMode.HEX"
+                Variant="Variant.Outlined" />
+```
+
+`@bind-Text` binds to a hex string (e.g. `"#d73a4a"`). Use `@bind-Value` to bind to a `MudColor` value object instead.
+
+### Data Grid
+
+See [references/DATAGRID.md](references/DATAGRID.md) for full grid patterns.
+
+```razor
+<MudDataGrid Items="@_items" Filterable="true" SortMode="SortMode.Multiple"
+             Hover="true" Striped="true" Dense="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" />
+        <PropertyColumn Property="x => x.Status" Title="Status" />
+        <TemplateColumn Title="Actions" CellClass="d-flex justify-end">
+            <CellTemplate>
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit"
+                               OnClick="@(() => Edit(context.Item))" />
+            </CellTemplate>
+        </TemplateColumn>
+    </Columns>
+</MudDataGrid>
+```
+
+---
+
+## Dialog Service Pattern
+
+### Service injection
+
+```csharp
+[Inject] private IDialogService DialogService { get; set; } = default!;
+```
+
+### Opening a dialog
+
+```csharp
+var parameters = new DialogParameters<MyDialog>
+{
+    { x => x.Item, _selectedItem }
+};
+var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true };
+var dialog = await DialogService.ShowAsync<MyDialog>("Edit Item", parameters, options);
+var result = await dialog.Result;
+
+if (!result.Canceled)
+{
+    // handle confirmed result
+}
+```
+
+### Dialog component
+
+```razor
+@* MyDialog.razor *@
+<MudDialog>
+    <TitleContent>Edit Item</TitleContent>
+    <DialogContent>
+        <MudTextField @bind-Value="_name" Label="Name" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@Submit">Save</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public ItemDto Item { get; set; } = default!;
+
+    private string _name = string.Empty;
+
+    protected override void OnParametersSet() => _name = Item.Name;
+
+    private void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(_name));
+}
+```
+
+---
+
+## Snackbar / Notification Pattern
+
+```csharp
+[Inject] private ISnackbar Snackbar { get; set; } = default!;
+
+// Usage:
+Snackbar.Add("Item created successfully.", Severity.Success);
+Snackbar.Add("Failed to create item.", Severity.Error);
+Snackbar.Add("No items selected.", Severity.Warning);
+```
+
+---
+
+## Loading State Pattern
+
+```razor
+@if (_loading)
+{
+    <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+}
+else
+{
+    @* content *@
+}
+```
+
+---
+
+## Icons
+
+MudBlazor includes Material Icons:
+
+```razor
+Icon="@Icons.Material.Filled.Inventory2"   @* filled variant *@
+Icon="@Icons.Material.Outlined.Delete"     @* outlined variant *@
+Icon="@Icons.Material.TwoTone.Settings"    @* two-tone variant *@
+```
+
+---
+
+## Theming
+
+See [references/THEMING.md](references/THEMING.md) for custom palette setup.
+
+```razor
+@* MainLayout.razor *@
+<MudThemeProvider Theme="_theme" />
+
+@code {
+    private MudTheme _theme = new()
+    {
+        PaletteLight = new PaletteLight
+        {
+            Primary = "#1976D2",
+            Secondary = "#424242",
+            AppbarBackground = "#1976D2"
+        }
+    };
+}
+```
+
+---
+
+## Known Pitfalls
+
+See [references/KNOWN-PITFALLS.md](references/KNOWN-PITFALLS.md) for full details and troubleshooting steps.
+
+Quick checks:
+- Provider components missing in `MainLayout.razor` (`MudPopoverProvider`, `MudDialogProvider`, `MudSnackbarProvider`) cause silent UI failures.
+- Two-way binding on `MudColorPicker` should use `@bind-Text` for hex strings.
+- Custom CSS should remain a fallback after components, parameters, theme settings, and utility classes.
+
+---
+
+## Optional bUnit Testing
+
+Use the test framework already present in the repository. If bUnit is already in use, see [references/BUNIT.md](references/BUNIT.md) for setup patterns and examples.
+
+```csharp
+// Register MudBlazor services in the test context
+ctx.Services.AddMudServices();
+
+// Suppress MudBlazor JS interop calls that surface in unit tests
+ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+```

--- a/.github/skills/mudblazor-mh/references/BUNIT.md
+++ b/.github/skills/mudblazor-mh/references/BUNIT.md
@@ -1,0 +1,133 @@
+# MudBlazor bUnit Testing (Optional)
+
+Optional reference for testing MudBlazor components with bUnit when bUnit is already adopted in the repository.
+
+If the repository uses a different test stack, keep that stack and adapt these examples conceptually rather than introducing bUnit by default.
+
+---
+
+## Test Context Setup
+
+```csharp
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using Moq;
+using Xunit;
+
+public class ItemsPageTests : BunitContext
+{
+    public ItemsPageTests()
+    {
+        // Register MudBlazor services
+        Services.AddMudServices();
+
+        // MudBlazor uses JS interop; use Loose mode to suppress unknown calls
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+}
+```
+
+---
+
+## Rendering a Page Component
+
+```csharp
+[Fact]
+public void ItemsPage_RendersDataGrid_WhenItemsLoaded()
+{
+    // Arrange
+    var mockService = new Mock<IItemService>();
+    mockService.Setup(s => s.GetItemsAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync([new ItemDto("Sample item", "#d73a4a", "Example description", [])]);
+    Services.AddSingleton(mockService.Object);
+
+    // Act
+    var cut = RenderComponent<Items>();
+
+    // Assert
+    cut.WaitForElement(".mud-table-root");
+    Assert.Contains("Sample item", cut.Markup);
+}
+```
+
+---
+
+## Testing Dialog Interactions
+
+MudBlazor dialogs are opened via `IDialogService`. In bUnit tests, add `MudDialogProvider` as a sibling or use a wrapping layout:
+
+```csharp
+[Fact]
+public async Task CreateButton_OpensCreateDialog()
+{
+    // Register dialog service (already covered by AddMudServices)
+    var cut = RenderComponent<Items>();
+
+    cut.Find("[data-testid='create-button']").Click();
+
+    cut.WaitForElement(".mud-dialog");
+    Assert.Contains("Create Item", cut.Markup);
+}
+```
+
+---
+
+## Testing Snackbar Messages
+
+`ISnackbar` is registered by `AddMudServices()`. You can verify calls via mock injection if needed:
+
+```csharp
+var snackbarMock = new Mock<ISnackbar>();
+Services.AddSingleton(snackbarMock.Object);
+
+// ... trigger action ...
+
+snackbarMock.Verify(s => s.Add(
+    It.Is<string>(m => m.Contains("created")),
+    Severity.Success,
+    It.IsAny<Action<SnackbarOptions>>(),
+    It.IsAny<string>()),
+    Times.Once);
+```
+
+---
+
+## WaitForState and Async Rendering
+
+MudBlazor components often trigger async re-renders. Use bUnit's `WaitForState` / `WaitForElement`:
+
+```csharp
+var cut = RenderComponent<Items>();
+
+// Wait for loading state to complete
+cut.WaitForState(() => !cut.Markup.Contains("mud-progress-circular"), TimeSpan.FromSeconds(2));
+
+Assert.Contains("mud-data-grid", cut.Markup);
+```
+
+---
+
+## Common Test Patterns
+
+### Assert component renders without exception
+
+```csharp
+var cut = RenderComponent<Dashboard>();
+Assert.NotNull(cut);
+```
+
+### Assert navigation link exists
+
+```csharp
+var cut = RenderComponent<NavMenu>();
+Assert.NotEmpty(cut.FindAll("a[href='/items']"));
+```
+
+### Assert data grid row count
+
+```csharp
+var rows = cut.FindAll(".mud-table-row");
+Assert.Equal(expectedCount, rows.Count);
+```

--- a/.github/skills/mudblazor-mh/references/BUTTONS.md
+++ b/.github/skills/mudblazor-mh/references/BUTTONS.md
@@ -1,0 +1,28 @@
+# MudBlazor Buttons
+
+Use this reference when choosing between action-oriented MudBlazor components.
+
+## Decision Guidance
+
+- Use `MudButton` for most text-labelled actions.
+- Use `MudIconButton` for compact icon-only actions where the icon is unambiguous.
+- Use `MudButtonGroup` when multiple related actions should read as one control set.
+- Use `MudFab` for the primary floating action on a page.
+- Use `MudToggleIconButton` when a boolean state needs icon-based on/off feedback.
+- Use `MudScrollToTop` for long pages where users need a fast return to the top.
+
+## Component Coverage
+
+| Component | When to use it | Notes |
+|-----------|----------------|-------|
+| `MudButton` | Primary, secondary, neutral, and destructive actions with a text label. | Prefer `Variant` and `Color` over custom CSS styling. |
+| `MudButtonGroup` | Grouped actions where visual adjacency communicates relationship. | Useful for segmented controls and grouped command bars. |
+| `MudFab` | Prominent page-level call to action. | Keep usage rare; one floating primary action per page section is usually enough. |
+| `MudIconButton` | Small icon-only actions in tables, lists, cards, or toolbars. | Pair with tooltip text when icon meaning may be ambiguous. |
+| `MudToggleIconButton` | Toggled states such as favourite, pinned, muted, or enabled/disabled. | Use stateful icon and colour differences to make state clear. |
+| `MudScrollToTop` | Long vertically scrolling content. | Prefer this over custom JavaScript scroll controls. |
+
+## Related References
+
+- For button colour and intent hierarchy, see `COMPONENT-CHOOSER.md`.
+- For top bar and command placement, see `LAYOUT-NAVIGATION.md`.

--- a/.github/skills/mudblazor-mh/references/COMPONENT-CHOOSER.md
+++ b/.github/skills/mudblazor-mh/references/COMPONENT-CHOOSER.md
@@ -1,0 +1,107 @@
+# MudBlazor Component Chooser
+
+Map UI patterns to the correct MudBlazor component. Never use a raw HTML element where a MudBlazor component exists.
+
+Decision order for UI composition:
+1. Pick a MudBlazor component.
+2. Compose with MudBlazor layout primitives.
+3. Use MudBlazor utility classes in `Class`.
+4. Fall back to isolated CSS only when the first three options cannot satisfy the requirement.
+
+## Button Semantics and Colour Hierarchy
+
+Use button colour and variant to communicate intent consistently across pages.
+
+- `Color.Primary` with `Variant.Filled` is for commit actions that move work forward, such as create, save, apply, or confirm.
+- `Color.Secondary` is for meaningful non-commit actions, such as load, preview, open, or retry.
+- `Color.Default` is for neutral actions, such as edit, close, dismiss, or low-risk utility actions.
+- `Color.Error` is for destructive actions, such as delete.
+- `Variant.Text` is preferred for cancel actions.
+- `Variant.Outlined` is preferred for secondary and neutral actions when you want reduced visual emphasis.
+- Avoid using `Color.Primary` for every action in the same section, because this weakens visual hierarchy.
+
+| UI Pattern | MudBlazor Component | Notes |
+|------------|---------------------|-------|
+| Page section wrapper | `MudPaper`, `MudCard`, or `MudContainer` | Avoid decorative `<div>` wrappers. |
+| Responsive page layout | `MudGrid` + `MudItem` | Prefer over custom grid CSS. |
+| Single-line text input | `MudTextField<T>` | Use `Variant="Variant.Outlined"` |
+| Read-only text / heading | `MudText` | Prefer over styled `<p>` / `<h*>` wrappers when typography is the main concern. |
+| Multi-line text / textarea | `MudTextField<T>` with `Lines="N"` | Not `<textarea>` |
+| Password input | `MudTextField<string>` with `InputType.Password` | Includes show/hide toggle |
+| Search box | `MudTextField<string>` with `Adornment.End` search icon | Not `<input type="search">` |
+| Number input | `MudNumericField<T>` | Handles min/max/step |
+| Single select / dropdown | `MudSelect<T>` + `MudSelectItem<T>` | Not `<select>` |
+| Autocomplete (type-ahead) | `MudAutocomplete<T>` | Popup via `MudPopoverProvider` |
+| Multi-select checkbox list | `MudSelect<T>` with `MultiSelection="true"` | Or list of `MudCheckBox` |
+| Checkbox | `MudCheckBox<bool>` | Not `<input type="checkbox">` |
+| Toggle / switch | `MudSwitch<bool>` | Not `<input type="checkbox">` |
+| Radio group | `MudRadioGroup<T>` + `MudRadio<T>` | Not `<input type="radio">` |
+| Colour picker | `MudColorPicker` | First-class; no hand-rolling needed |
+| Date picker | `MudDatePicker` | Not `<input type="date">` |
+| Time picker | `MudTimePicker` | Not `<input type="time">` |
+| Button (primary action) | `MudButton Variant="Variant.Filled"` | Not `<button>` |
+| Button (secondary/ghost) | `MudButton Variant="Variant.Outlined"` | |
+| Button (text-only link) | `MudButton Variant="Variant.Text"` | |
+| Icon-only button | `MudIconButton` | Not `<button><img></button>` |
+| Floating action button | `MudFab` | |
+| Data table / grid | `MudDataGrid<T>` | With `PropertyColumn` / `TemplateColumn` |
+| Simple read-only table | `MudTable<T>` | Lighter than DataGrid |
+| Card / panel | `MudCard` or `MudPaper` | Not `<div class="card">` |
+| Expandable panel | `MudExpansionPanel` | |
+| Tabs | `MudTabs` + `MudTabPanel` | |
+| Navigation sidebar | `MudNavMenu` + `MudNavLink` + `MudNavGroup` | |
+| App bar / header | `MudAppBar` | |
+| Loading spinner | `MudProgressCircular` | Indeterminate or determinate |
+| Progress bar | `MudProgressLinear` | |
+| Alert / info banner | `MudAlert` | Not `<div class="alert">` |
+| Notification toast | `ISnackbar.Add(...)` | Service injection; `MudSnackbarProvider` required |
+| Modal dialog | `IDialogService.ShowAsync<T>()` | `MudDialogProvider` required |
+| Tooltip | `MudTooltip` | |
+| Chip / tag | `MudChip<T>` | |
+| Chip set (multi) | `MudChipSet<T>` | |
+| Badge | `MudBadge` | |
+| Divider | `MudDivider` | Not `<hr>` |
+| Spacer (flex) | `MudSpacer` | Inside `MudAppBar` or `MudStack` |
+| Horizontal stack | `MudStack Row="true"` | Not `<div class="d-flex">` |
+| Vertical stack | `MudStack` | |
+| Spacing / alignment adjustment | `Class` with MudBlazor utility classes | Prefer `pa-*`, `ma-*`, `d-flex`, `justify-*`, `align-*` over custom CSS. |
+| Breakpoint visibility | `MudHidden` | Prefer over custom media-query CSS for show/hide behaviour. |
+| Avatar / icon circle | `MudAvatar` | |
+| Colour swatch display | `MudChip` with background colour style | |
+
+## Additional Official Components
+
+Use this section for components available in the official MudBlazor overview that are less common but still worth considering before falling back to custom UI.
+
+| UI Pattern | MudBlazor Component | Notes |
+|------------|---------------------|-------|
+| Grouped adjacent actions | `MudButtonGroup` | See `BUTTONS.md` for grouping guidance. |
+| Icon toggle state control | `MudToggleIconButton` | Use for pinned, favourite, muted, and similar icon-first booleans. |
+| Long-page return affordance | `MudScrollToTop` | Prefer over custom JavaScript scrolling controls. |
+| Section command strip | `MudToolBar` | Use for local command areas inside sections and cards. |
+| Custom field shell around bespoke content | `MudField` | Use for consistent labels and helper text around custom content. |
+| File selection and upload | `MudFileUpload<T>` | Validate file type and size constraints explicitly. |
+| Coordinated validation across fields | `MudForm` | Keep form-level validity and submit behaviour centralised. |
+| Focus-trapped interaction region | `MudFocusTrap` | Useful in constrained overlays and accessibility-sensitive flows. |
+| Text highlight of search matches | `MudHighlighter` | Pair with filtered search result rendering. |
+| Rating input or display | `MudRating` | Use for sentiment-style scoring interactions. |
+| Range and threshold tuning | `MudSlider<T>` | Prefer over free-form numeric text for bounded ranges. |
+| Segmented mode toggles | `MudToggleGroup<T>` | Good for compact option groups. |
+| Rich contextual menu | `MudMenu` | Use for overflow and contextual actions. |
+| Hierarchical breadcrumb path | `MudBreadcrumbs` | Use for deep navigation context. |
+| Themed inline navigation link | `MudLink` | Prefer over raw styled anchors where appropriate. |
+| Structured non-tabular lists | `MudList<T>` + `MudListItem<T>` | Use when table columns are unnecessary. |
+| Lightweight paging controls | `MudPagination` | Pair with server-side or in-memory paging. |
+| Anchored contextual surface | `MudPopover` | Ensure dismiss and focus behaviour are clear. |
+| Lightweight static read-only table | `MudSimpleTable` | Prefer for static or minimally dynamic read-only tabular summaries; use `MudTable<T>` when you need sorting, paging, selection, or templated cells. |
+| Chronological event feed | `MudTimeline` | Useful for audit and history visualisation. |
+| Hierarchical data explorer | `MudTreeView<T>` | Use for nested structures and explorer-style navigation. |
+| Drag-and-drop target and reorder region | `MudDropZone<T>` | Useful for visual ordering workflows. |
+| Rotating visual panels | `MudCarousel` | Use sparingly and avoid critical information in carousels. |
+| Conversational message thread view | `MudChat` | Suitable for chat-like or assistant-style interactions. |
+| Themed responsive image display | `MudImage` | Prefer over raw image tags when component features are needed. |
+| Standard confirmation prompt | `MudMessageBox` | Use for straightforward confirm and acknowledge flows. |
+| Loading-state placeholders | `MudSkeleton` | Improves perceived loading quality on content-heavy views. |
+| Backdrop and blocking layer | `MudOverlay` | Use for blocking busy states and modal emphasis. |
+
+For complete grouped guidance, see `INPUTS.md`, `BUTTONS.md`, `LAYOUT-NAVIGATION.md`, `DATA-DISPLAY.md`, and `FEEDBACK-OVERLAYS.md`.

--- a/.github/skills/mudblazor-mh/references/DATA-DISPLAY.md
+++ b/.github/skills/mudblazor-mh/references/DATA-DISPLAY.md
@@ -1,0 +1,39 @@
+# MudBlazor Data Display
+
+Use this reference for read-heavy views, structured information, and visual presentation components.
+
+## Component Coverage
+
+| Component | When to use it | Notes |
+|-----------|----------------|-------|
+| `MudAvatar` | User or entity avatar visuals. | Use in lists, cards, and activity streams. |
+| `MudCard` | Information grouped as card content. | Suitable for dashboard summaries and compact records. |
+| `MudCarousel` | Rotating set of visual slides. | Use sparingly; avoid for critical information. |
+| `MudChat` | Chat-style message thread presentation. | Suitable for conversational or assistant-like interactions. |
+| `MudChip<T>` | Compact labels, facets, or status indicators. | Works well with filters and taxonomy badges. |
+| `MudChipSet<T>` | Coordinated chip selection groups. | Useful for filter bars and quick selectors. |
+| `MudDataGrid<T>` | Rich tabular data with filtering, sorting, and templates. | Prefer for feature-rich interactive tables. |
+| `MudDropZone<T>` | Drag-and-drop target and reorder interactions. | Useful for visual ordering and workflow mapping interfaces. |
+| `MudExpansionPanels` | Collapsible grouped sections. | Ideal for advanced settings and dense forms. |
+| `MudImage` | Responsive and themed image rendering. | Prefer over raw `<img>` when MudBlazor behaviours are useful. |
+| `MudList<T>` + `MudListItem<T>` | Lightweight list presentation and selection. | Choose over tables when columns are unnecessary. |
+| `MudPagination` | Page navigation controls for paged content. | Pair with server-side paging logic where needed. |
+| `MudPopover` | Anchored content surface for contextual detail. | Use with care; ensure focus and dismiss behaviour are clear. |
+| `MudSimpleTable` | Low-friction static table rendering. | Good for read-only compact tabular details. |
+| `MudTable<T>` | Data table with moderate capabilities. | Prefer when `MudDataGrid<T>` features are unnecessary. |
+| `MudTabs` + `MudTabPanel` | Segmented content areas. | Useful for mode switches and detail partitioning. |
+| `MudTimeline` + timeline items | Chronological event display. | Good fit for audit and activity histories. |
+| `MudTreeView<T>` + `MudTreeViewItem<T>` | Hierarchical data and nested structures. | Suitable for file-like trees and rule hierarchies. |
+
+## Table and Grid Guidance
+
+- Use `MudSimpleTable` for static data with no interactive operations.
+- Use `MudTable<T>` for moderate interaction needs.
+- Use `MudDataGrid<T>` when advanced filtering, template columns, or richer interactions are required.
+
+For concrete grid patterns, see `DATAGRID.md`.
+
+## Related References
+
+- For action controls within displayed data, see `BUTTONS.md`.
+- For notifications and transient UI tied to display actions, see `FEEDBACK-OVERLAYS.md`.

--- a/.github/skills/mudblazor-mh/references/DATAGRID.md
+++ b/.github/skills/mudblazor-mh/references/DATAGRID.md
@@ -1,0 +1,128 @@
+# MudBlazor Data Grid Patterns
+
+Reference for `MudDataGrid<T>` usage in MudBlazor applications.
+
+---
+
+## Table Selection Guidance
+
+Choose the lightest table component that satisfies the scenario.
+
+- Use `MudSimpleTable` for static read-only tabular summaries with no interaction.
+- Use `MudTable<T>` for moderate tabular interaction and straightforward templating.
+- Use `MudDataGrid<T>` when richer interactions are needed, such as multi-sort, filtering, selectable rows, and template-heavy columns.
+
+If uncertain, start with `MudTable<T>` and move to `MudDataGrid<T>` only when a concrete feature requires advanced grid capabilities.
+
+---
+
+## Basic Setup
+
+```razor
+<MudDataGrid T="ItemDto" Items="@_items" Filterable="true"
+             SortMode="SortMode.Multiple" Hover="true" Dense="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" Sortable="true" />
+        <PropertyColumn Property="x => x.Colour" Title="Colour" />
+        <TemplateColumn Title="Actions" CellClass="d-flex justify-end" Sortable="false">
+            <CellTemplate>
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit"
+                               Color="Color.Primary"
+                               OnClick="@(() => OpenEditDialog(context.Item))" />
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Delete"
+                               Color="Color.Error"
+                               OnClick="@(() => OpenDeleteDialog(context.Item))" />
+            </CellTemplate>
+        </TemplateColumn>
+    </Columns>
+</MudDataGrid>
+```
+
+---
+
+## Loading State
+
+Wrap the grid with a loading check; use `MudProgressCircular` while data is loading:
+
+```razor
+@if (_loading)
+{
+    <MudProgressCircular Indeterminate="true" Color="Color.Primary" Class="my-4" />
+}
+else if (_items.Count == 0)
+{
+    <MudText Typo="Typo.body1" Class="pa-4">No items found.</MudText>
+}
+else
+{
+    <MudDataGrid ... />
+}
+```
+
+---
+
+## Server-side / Async Data
+
+Use the `ServerData` delegate for large datasets fetched asynchronously:
+
+```razor
+<MudDataGrid T="ItemDto" ServerData="@LoadServerData" @ref="_grid">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private MudDataGrid<ItemDto>? _grid;
+
+    private async Task<GridData<ItemDto>> LoadServerData(GridState<ItemDto> state)
+    {
+        var items = await ItemService.GetItemsAsync();
+        return new GridData<ItemDto>
+        {
+            Items = items,
+            TotalItems = items.Count
+        };
+    }
+}
+```
+
+---
+
+## Row Selection
+
+```razor
+<MudDataGrid T="ItemDto" Items="@_items" SelectedItemsChanged="@OnSelectionChanged"
+             MultiSelection="true">
+    ...
+</MudDataGrid>
+
+@code {
+    private HashSet<ItemDto> _selected = [];
+
+    private void OnSelectionChanged(HashSet<ItemDto> items) => _selected = items;
+}
+```
+
+---
+
+## Custom Cell Rendering (colour swatch example)
+
+```razor
+<TemplateColumn Title="Colour">
+    <CellTemplate>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <div style="width:16px;height:16px;border-radius:50%;
+                        background-color:@context.Item.Colour;
+                        border:1px solid rgba(0,0,0,0.12);" />
+            <MudText Typo="Typo.body2">@context.Item.Colour</MudText>
+        </MudStack>
+    </CellTemplate>
+</TemplateColumn>
+```
+
+---
+
+## No z-index / stacking issues
+
+MudBlazor's `MudDataGrid` sticky headers use inline CSS and do not conflict with `MudAutocomplete` or `MudSelect` popups. The `MudPopoverProvider` in `MainLayout.razor` ensures popup components render at document body level, above all grid content.

--- a/.github/skills/mudblazor-mh/references/FEEDBACK-OVERLAYS.md
+++ b/.github/skills/mudblazor-mh/references/FEEDBACK-OVERLAYS.md
@@ -1,0 +1,28 @@
+# MudBlazor Feedback and Overlays
+
+Use this reference for user feedback, status communication, and transient surfaces.
+
+## Component Coverage
+
+| Component | When to use it | Notes |
+|-----------|----------------|-------|
+| `MudAlert` | Inline contextual information, warnings, or errors. | Use for page-local messages that should remain visible. |
+| `MudBadge` | Counts and concise status markers. | Pair with icons and tabs for lightweight indicators. |
+| `MudDialog` via `IDialogService` | Modal flows requiring focused interaction. | Requires `MudDialogProvider` in layout. |
+| `MudMessageBox` via service helpers | Standard confirmation and acknowledgement prompts. | Prefer for straightforward yes/no or ok/cancel prompts. |
+| `MudOverlay` | Backdrop or blocking surface overlays. | Useful for busy states and controlled modal emphasis. |
+| `MudProgressCircular` and `MudProgressLinear` | Loading and progress indication. | Choose circular for localised loading and linear for process progression. |
+| `MudSkeleton` | Loading placeholders while content hydrates. | Improves perceived performance in content-heavy views. |
+| `ISnackbar` with `MudSnackbarProvider` | Non-blocking global toasts. | Use for operation outcomes and short-lived notifications. |
+
+## Decision Guidance
+
+- Use `MudAlert` when the message should stay anchored in page context.
+- Use snackbar for brief outcomes that do not require immediate action.
+- Use dialog or message box when explicit acknowledgement is required.
+- Use skeletons for content loading states where layout stability matters.
+
+## Related References
+
+- For provider setup and service injection patterns, see `../SKILL.md`.
+- For common provider and popup failures, see `KNOWN-PITFALLS.md`.

--- a/.github/skills/mudblazor-mh/references/INPUTS.md
+++ b/.github/skills/mudblazor-mh/references/INPUTS.md
@@ -1,0 +1,41 @@
+# MudBlazor Inputs
+
+Use this reference when selecting data entry and input components.
+
+## Decision Guidance
+
+- Use `MudTextField<T>` for most text capture scenarios.
+- Use `MudNumericField<T>` for constrained numeric values.
+- Use `MudSelect<T>` for known finite choices.
+- Use `MudAutocomplete<T>` for large option sets and type-ahead.
+- Use picker components such as `MudDatePicker`, `MudTimePicker`, and `MudColorPicker` for specialised value types.
+- Use `MudForm` when coordinating validation and submission across multiple fields.
+
+## Component Coverage
+
+| Component | When to use it | Notes |
+|-----------|----------------|-------|
+| `MudAutocomplete<T>` | Type-ahead selection from larger collections. | Requires `MudPopoverProvider` in layout. |
+| `MudCheckBox<T>` | Boolean input or checklist options. | Prefer over raw HTML checkboxes. |
+| `MudColorPicker` | Colour selection with HEX, RGB, or palette style workflows. | Use `@bind-Text` for hex string models. |
+| `MudDatePicker` | Single date capture. | Use for schedules, due dates, and filters. |
+| `MudField` | Shared field shell for custom input experiences. | Use when composing custom field content with consistent label and helper behaviour. |
+| `MudFileUpload<T>` | File selection and upload workflows. | Keep validation explicit for file type and size constraints. |
+| `MudForm` | Coordinated validation and submit flow across fields. | Use `Validate()` and form-level state instead of ad hoc per-control checks. |
+| `MudFocusTrap` | Keep focus within a scoped region. | Useful for accessibility in dialogs and constrained overlays. |
+| `MudHighlighter` | Highlight matched text fragments in search results. | Pair with user search text and sanitised matching logic. |
+| `MudNumericField<T>` | Numeric values with min, max, and step. | Prefer this over text field parsing for numbers. |
+| `MudRadioGroup<T>` + `MudRadio<T>` | Single selection from a short mutually exclusive set. | Better than a select for small visible option groups. |
+| `MudRating` | Rating input or display using stars or custom symbols. | Use for sentiment-style scoring, not critical binary decisions. |
+| `MudSelect<T>` + `MudSelectItem<T>` | Dropdown for finite known options. | Supports multi-select when `MultiSelection="true"`. |
+| `MudSlider<T>` | Range-based value selection. | Useful for bounded thresholds and tuning values. |
+| `MudSwitch<T>` | Binary on/off state with immediate affordance. | Prefer where toggle semantics are clearer than checkbox semantics. |
+| `MudTextField<T>` | Single-line and multi-line text input. | Supports adornments, masks, counters, and input type variants. |
+| `MudTimePicker` | Time selection with 12h or 24h modes. | Bind with `@bind-Time` for `TimeSpan?` models. |
+| `MudToggleGroup<T>` | Exclusive or multi-toggle selection via button-like options. | Useful for quick mode switches and compact option sets. |
+
+## Related References
+
+- For provider requirements and baseline setup, see `../SKILL.md`.
+- For popover-related issues, see `KNOWN-PITFALLS.md`.
+- For quick pattern matching, see `COMPONENT-CHOOSER.md`.

--- a/.github/skills/mudblazor-mh/references/KNOWN-PITFALLS.md
+++ b/.github/skills/mudblazor-mh/references/KNOWN-PITFALLS.md
@@ -1,0 +1,209 @@
+# MudBlazor Known Pitfalls
+
+Operational diagnosis guidance for common MudBlazor issues.
+
+---
+
+## Pitfall 1: Popup components render nothing (missing MudPopoverProvider)
+
+**Symptom:** `MudAutocomplete`, `MudSelect`, `MudDatePicker`, or `MudTimePicker` dropdown opens but is empty, or opens but immediately closes, or renders no dropdown at all.
+
+**Root cause:** `MudPopoverProvider` is missing from `MainLayout.razor`.
+
+**Fix:**
+
+```razor
+@* MainLayout.razor - ensure this is present alongside the other providers *@
+<MudThemeProvider />
+<MudPopoverProvider />   <!-- ← this is the fix -->
+<MudDialogProvider />
+<MudSnackbarProvider />
+```
+
+---
+
+## Pitfall 2: Dialog service calls silently do nothing (missing MudDialogProvider)
+
+**Symptom:** `await DialogService.ShowAsync<T>(...)` returns immediately with a cancelled result and no dialog appears.
+
+**Root cause:** `MudDialogProvider` is missing from `MainLayout.razor`.
+
+**Fix:** Add `<MudDialogProvider />` to `MainLayout.razor` (see Pitfall 1 for full provider list).
+
+---
+
+## Pitfall 3: Snackbar notifications never appear (missing MudSnackbarProvider)
+
+**Symptom:** `Snackbar.Add(...)` is called but no notification appears.
+
+**Root cause:** `MudSnackbarProvider` is missing from `MainLayout.razor`.
+
+**Fix:** Add `<MudSnackbarProvider />` to `MainLayout.razor`.
+
+---
+
+## Pitfall 4: MudColorPicker - binding a hex string
+
+**Symptom:** Two-way binding on `MudColorPicker` fails or the value does not update.
+
+**Cause:** Confusion between `@bind-Value` (binds `MudColor` object) and `@bind-Text` (binds `string`).
+
+**Fix:** When the model field is a `string` (e.g. `"#d73a4a"`), use `@bind-Text`:
+
+```razor
+<MudColorPicker @bind-Text="_hexColour" Label="Colour"
+                ColorPickerMode="ColorPickerMode.HEX"
+                Variant="Variant.Outlined" />
+```
+
+To convert between `MudColor` and `string`: `new MudColor(hexString)` or `mudColor.ToString("#")`.
+
+---
+
+## Pitfall 5: MudDataGrid filterable requires column filterable setup
+
+**Symptom:** Grid has `Filterable="true"` but no filter UI appears on columns.
+
+**Cause:** Filterable grid requires `FilterMode` and optionally `FilterDefinition`.
+
+**Fix:** For simple column filtering, ensure `Filterable="true"` is on the grid and columns use `PropertyColumn` (which infers filter type automatically):
+
+```razor
+<MudDataGrid T="ItemDto" Items="@_items" Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterRow">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" />
+    </Columns>
+</MudDataGrid>
+```
+
+---
+
+## Pitfall 6: bUnit tests - MudBlazor JS interop errors
+
+**Symptom:** bUnit tests throw `JSException` or similar during component render.
+
+**Cause:** MudBlazor uses JS interop for some interactions (ripple effects, popover positioning). bUnit's strict JS interop mode throws on unexpected calls.
+
+**Fix:**
+
+```csharp
+// In test setup:
+ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+ctx.Services.AddMudServices();
+```
+
+---
+
+## Pitfall 7: MudDrawer not toggling (missing @bind-Open)
+
+**Symptom:** Hamburger menu button does nothing; drawer state doesn't update.
+
+**Fix:** Use `@bind-Open` on `MudDrawer` and maintain a `bool _drawerOpen` field:
+
+```razor
+<MudDrawer @bind-Open="_drawerOpen">...</MudDrawer>
+
+@code {
+    private bool _drawerOpen = true;
+    private void ToggleDrawer() => _drawerOpen = !_drawerOpen;
+}
+```
+
+---
+
+## Pitfall 8: MudAutocomplete - SearchFunc must return Task
+
+**Symptom:** `MudAutocomplete` filter does not work or throws.
+
+**Fix:** `SearchFunc` must match the signature `Func<string, CancellationToken, Task<IEnumerable<T>>>`. Do not mark the method `async` unless it contains an `await`; return `Task.FromResult(...)` for synchronous implementations:
+
+```csharp
+private Task<IEnumerable<string>> SearchItems(string value, CancellationToken ct)
+{
+    if (string.IsNullOrWhiteSpace(value))
+        return Task.FromResult(_items.Select(r => r.Name));
+    return Task.FromResult(
+        _items.Where(r => r.Name.Contains(value, StringComparison.OrdinalIgnoreCase))
+              .Select(r => r.Name));
+}
+```
+
+---
+
+## Pitfall 9: MudMenu and MudPopover clipped or hidden
+
+**Symptom:** Menu or popover content appears cut off, hidden behind other surfaces, or not visible near container edges.
+
+**Cause:** Missing provider setup, restrictive parent overflow styling, or assumptions about local z-index stacking.
+
+**Fix:**
+
+- Confirm `MudPopoverProvider` is present in `MainLayout.razor`.
+- Avoid custom container styles such as `overflow: hidden` around menu and popover triggers unless clipping is intentional.
+- Prefer MudBlazor layout primitives and defaults over custom z-index adjustments.
+
+---
+
+## Pitfall 10: MudForm validation state not updating as expected
+
+**Symptom:** Submit actions proceed while invalid fields are present, or validation messages do not appear until too late.
+
+**Cause:** Form-level validation is bypassed and controls are validated ad hoc.
+
+**Fix:** Keep validation coordinated through `MudForm`.
+
+```razor
+<MudForm @ref="_form">
+    <MudTextField @bind-Value="_name" Label="Name" Required="true" />
+    <MudButton OnClick="@SubmitAsync">Save</MudButton>
+</MudForm>
+
+@code {
+    private MudForm? _form;
+    private string _name = string.Empty;
+
+    private async Task SubmitAsync()
+    {
+        await _form!.Validate();
+        if (!_form.IsValid)
+            return;
+
+        // Continue with save.
+    }
+}
+```
+
+---
+
+## Pitfall 11: File upload accepted with no guardrails
+
+**Symptom:** Unexpected file types or oversized files are processed.
+
+**Cause:** File selection is treated as trusted input.
+
+**Fix:** Validate uploaded files explicitly before processing.
+
+- Validate file count, file extension, and content type.
+- Enforce maximum file size in code.
+- Provide clear snackbar or inline validation feedback.
+
+---
+
+## Pitfall 12: Tabs lose intended active panel after rerender
+
+**Symptom:** Active tab jumps back unexpectedly after state changes.
+
+**Cause:** Active tab selection is not controlled when tab collection or conditional visibility changes.
+
+**Fix:** Bind and manage active panel explicitly when tabs are dynamic.
+
+```razor
+<MudTabs @bind-ActivePanelIndex="_activeTab">
+    <MudTabPanel Text="Overview" />
+    <MudTabPanel Text="Details" />
+</MudTabs>
+
+@code {
+    private int _activeTab;
+}
+```

--- a/.github/skills/mudblazor-mh/references/LAYOUT-NAVIGATION.md
+++ b/.github/skills/mudblazor-mh/references/LAYOUT-NAVIGATION.md
@@ -1,0 +1,39 @@
+# MudBlazor Layout and Navigation
+
+Use this reference when structuring pages, shell layout, and navigation affordances.
+
+## Layout Components
+
+| Component | When to use it | Notes |
+|-----------|----------------|-------|
+| `MudAppBar` | Top-level application bar and command strip. | Commonly paired with drawer toggles and page-level actions. |
+| `MudContainer` | Width-constrained page content area. | Helps maintain readable line lengths and consistent margins. |
+| `MudDivider` | Visual separation between content groups. | Prefer over raw `<hr>` elements. |
+| `MudDrawer` | Side navigation or secondary panel content. | Bind `@bind-Open` for predictable state handling. |
+| `MudGrid` + `MudItem` | Responsive column-based layouts. | Prefer over bespoke CSS grid for standard responsive layouts. |
+| `MudHidden` | Breakpoint-based conditional visibility. | Prefer over custom media-query show/hide CSS. |
+| `MudPaper` | Surface container with elevation and padding support. | Use for sections and panels requiring visual separation. |
+| `MudStack` | One-dimensional spacing and alignment layout. | Usually the quickest layout primitive for forms and card internals. |
+| `MudToolBar` | Inline command toolbar in sections or cards. | Useful for local action groups and filter bars. |
+
+## Navigation Components
+
+| Component | When to use it | Notes |
+|-----------|----------------|-------|
+| `MudBreadcrumbs` | Hierarchical page context and location path. | Useful for deep configuration flows. |
+| `MudLink` | Styled navigation links aligned with theme typography and colours. | Use for inline links in copy and helper text. |
+| `MudMenu` | Contextual menu actions anchored to a trigger. | Good for overflow actions in dense UIs. |
+| `MudNavMenu` + `MudNavLink` + `MudNavGroup` | Persistent app navigation structures. | Preferred for sidebar and grouped navigation. |
+
+## Decision Guidance
+
+- Start page structure with `MudContainer`, `MudStack`, and `MudPaper`.
+- Add `MudGrid` only when true responsive columns are needed.
+- Use `MudDrawer` and `MudNavMenu` for app shell navigation, not ad hoc link lists.
+- Use `MudMenu` for condensed action sets before introducing custom popovers.
+
+## Related References
+
+- For action components in bars and menus, see `BUTTONS.md`.
+- For overlays and transient surfaces, see `FEEDBACK-OVERLAYS.md`.
+- For full page shell setup, see `../SKILL.md`.

--- a/.github/skills/mudblazor-mh/references/THEMING.md
+++ b/.github/skills/mudblazor-mh/references/THEMING.md
@@ -1,0 +1,85 @@
+# MudBlazor Theming
+
+MudBlazor uses a `MudTheme` object passed to `MudThemeProvider`.
+
+---
+
+## Basic Custom Theme
+
+```razor
+@* MainLayout.razor *@
+<MudThemeProvider Theme="_theme" />
+
+@code {
+    private readonly MudTheme _theme = new()
+    {
+        PaletteLight = new PaletteLight
+        {
+            Primary = "#1976D2",
+            PrimaryDarken = "#115293",
+            PrimaryLighten = "#4791DB",
+            Secondary = "#616161",
+            AppbarBackground = "#1976D2",
+            Background = "#F5F5F5",
+            Surface = Colors.Shades.White,
+            DrawerBackground = Colors.Shades.White,
+            DrawerText = "rgba(0,0,0,0.87)",
+            Success = "#388E3C",
+            Error = "#D32F2F",
+            Warning = "#F57C00",
+            Info = "#1976D2"
+        },
+        PaletteDark = new PaletteDark
+        {
+            Primary = "#90CAF9",
+            AppbarBackground = "#1E1E2E"
+        },
+        Typography = new Typography
+        {
+            Default = new DefaultTypography
+            {
+                FontFamily = ["Inter", "Roboto", "Helvetica", "Arial", "sans-serif"]
+            }
+        }
+    };
+}
+```
+
+---
+
+## Dark Mode Toggle
+
+```razor
+<MudThemeProvider @bind-IsDarkMode="_isDark" Theme="_theme" />
+
+@code {
+    private bool _isDark;
+}
+```
+
+---
+
+## Using Theme Colours in Components
+
+```razor
+<MudButton Color="Color.Primary">Primary</MudButton>
+<MudButton Color="Color.Secondary">Secondary</MudButton>
+<MudButton Color="Color.Error">Delete</MudButton>
+<MudButton Color="Color.Success">Confirm</MudButton>
+```
+
+---
+
+Before reaching for CSS variables, prefer built-in component options such as `Color`, `Variant`, `Typo`, `Elevation`, `Square`, `Rounded`, `Dense`, and layout primitives plus utility classes.
+
+---
+
+## CSS Custom Properties
+
+MudBlazor exposes theme colours as CSS custom properties:
+- `var(--mud-palette-primary)`
+- `var(--mud-palette-primary-text)`
+- `var(--mud-palette-surface)`
+- `var(--mud-palette-background)`
+
+Use these in `.razor.css` files only for unavoidable custom styling that still needs to stay in sync with the theme.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="MudBlazor" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/FreeAgent.slnx
+++ b/FreeAgent.slnx
@@ -10,4 +10,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/FreeAgent.Client.Tests/FreeAgent.Client.Tests.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/FreeAgent.Client.Sample/FreeAgent.Client.Sample.csproj" />
+  </Folder>
 </Solution>

--- a/samples/FreeAgent.Client.Sample/Components/App.razor
+++ b/samples/FreeAgent.Client.Sample/Components/App.razor
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" />
+    <link href='@Assets["_content/MudBlazor/MudBlazor.min.css"]' rel="stylesheet" />
+    <link href="app.css" rel="stylesheet" />
+    <HeadOutlet @rendermode="InteractiveServer" />
+</head>
+<body>
+    <Routes @rendermode="InteractiveServer" />
+    <script src='@Assets["_content/MudBlazor/MudBlazor.min.js"]'></script>
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>

--- a/samples/FreeAgent.Client.Sample/Components/Layout/MainLayout.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Layout/MainLayout.razor
@@ -1,0 +1,85 @@
+@inherits LayoutComponentBase
+@inject TokenStore TokenStore
+
+<MudThemeProvider Theme="_theme" />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+<MudLayout>
+    <MudAppBar Elevation="0" Color="Color.Surface" Dense="true" Class="sample-appbar">
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+            <MudAvatar Size="Size.Medium" Color="Color.Primary" Variant="Variant.Filled">
+                <MudIcon Icon="@Icons.Material.Filled.Code" />
+            </MudAvatar>
+            <MudStack Spacing="0">
+                <MudText Typo="Typo.subtitle2">FreeAgent.NET</MudText>
+                <MudText Typo="Typo.caption" Class="shell-subtitle">Developer workbench for OAuth and API surface testing</MudText>
+            </MudStack>
+        </MudStack>
+
+        <MudSpacer />
+
+        <MudChip T="string"
+                 Color="@(TokenStore.IsConnected ? Color.Success : Color.Default)"
+                 Variant="Variant.Outlined"
+                 Size="Size.Small"
+                 Icon="@(TokenStore.IsConnected ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.RadioButtonUnchecked)">
+            @(TokenStore.IsConnected ? "Connected" : "Awaiting auth")
+        </MudChip>
+    </MudAppBar>
+
+    <MudDrawer Open="true" Elevation="0" Variant="DrawerVariant.Responsive" Class="sample-drawer">
+        <MudStack Class="drawer-header" Spacing="1">
+            <MudText Typo="Typo.overline" Class="drawer-label">Workspace</MudText>
+            <MudText Typo="Typo.h6">SDK Explorer</MudText>
+            <MudText Typo="Typo.body2" Class="drawer-copy">Use the sample to validate OAuth flow and probe implemented FreeAgent endpoints.</MudText>
+        </MudStack>
+
+        <MudDivider Class="mb-2" />
+
+        <MudNavMenu Rounded="true">
+            <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">
+                Overview
+            </MudNavLink>
+            <MudNavLink Href="/company" Icon="@Icons.Material.Filled.Business">
+                Company Probe
+            </MudNavLink>
+        </MudNavMenu>
+    </MudDrawer>
+
+    <MudMainContent Class="sample-main">
+        @Body
+    </MudMainContent>
+</MudLayout>
+
+@code {
+    private readonly MudTheme _theme = new()
+    {
+        PaletteLight = new PaletteLight
+        {
+            Primary = "#0f766e",
+            Secondary = "#b45309",
+            Tertiary = "#1d4ed8",
+            Background = "#f5f7f4",
+            Surface = "#fbfcfa",
+            AppbarBackground = "rgba(251, 252, 250, 0.92)",
+            DrawerBackground = "#f1f5f1",
+            DrawerText = "#16211d",
+            TextPrimary = "#16211d",
+            TextSecondary = "#50615b",
+            LinesDefault = "rgba(15, 23, 42, 0.08)"
+        },
+        LayoutProperties = new LayoutProperties
+        {
+            DrawerWidthLeft = "300px"
+        },
+        Typography = new Typography
+        {
+            Default = new DefaultTypography
+            {
+                FontFamily = ["Roboto", "Segoe UI", "sans-serif"]
+            }
+        }
+    };
+}

--- a/samples/FreeAgent.Client.Sample/Components/Pages/Company.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Pages/Company.razor
@@ -1,0 +1,190 @@
+@page "/company"
+@inject TokenStore TokenStore
+@inject OAuthService OAuthService
+@inject NavigationManager NavigationManager
+@inject IConfiguration Configuration
+
+<PageTitle>Company — FreeAgent SDK Sample</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.False" Class="sample-page">
+    <MudPaper Class="hero-panel compact" Elevation="0">
+        <MudGrid Spacing="3">
+            <MudItem xs="12" md="8">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.overline" Class="section-kicker">Implemented endpoint</MudText>
+                    <MudText Typo="Typo.h3">Company probe</MudText>
+                    <MudText Typo="Typo.body1" Class="hero-copy">
+                        Executes the current company service and shows the mapped SDK model.
+                        Use this page as a reference shape for future endpoint test surfaces.
+                    </MudText>
+                </MudStack>
+            </MudItem>
+            <MudItem xs="12" md="4">
+                <MudPaper Class="status-panel" Elevation="0">
+                    <MudStack Spacing="1">
+                        <MudText Typo="Typo.subtitle2">Execution target</MudText>
+                        <MudText Typo="Typo.body2"><strong>Configured environment:</strong> @EnvironmentName</MudText>
+                        <MudText Typo="Typo.body2"><strong>SDK API target:</strong> @SdkApiBaseUrl</MudText>
+                        <MudText Typo="Typo.body2"><strong>Endpoint path:</strong> /v2/company</MudText>
+                    </MudStack>
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
+
+    @if (!TokenStore.IsConnected)
+    {
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+            This probe needs an OAuth session first.
+            <MudLink Href="/">Return to overview</MudLink> and connect to FreeAgent.
+        </MudAlert>
+    }
+    else
+    {
+        <MudGrid Spacing="3">
+            <MudItem xs="12" md="4">
+                <MudPaper Class="workbench-panel" Elevation="0">
+                    <MudStack Spacing="3">
+                        <MudText Typo="Typo.h5">Run probe</MudText>
+                        <MudText Typo="Typo.body2">Send a GET request through the SDK using the active in-memory token.</MudText>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.CloudDownload"
+                                   Disabled="_loading"
+                                   OnClick="FetchCompanyAsync">
+                            @if (_loading)
+                            {
+                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                                <span>Running…</span>
+                            }
+                            else
+                            {
+                                <span>Fetch company</span>
+                            }
+                        </MudButton>
+
+                        @if (_company is not null)
+                        {
+                            <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Outlined">
+                                Probe completed successfully.
+                            </MudAlert>
+                        }
+                    </MudStack>
+                </MudPaper>
+            </MudItem>
+
+            <MudItem xs="12" md="8">
+                <MudStack Spacing="3">
+                    @if (_error is not null)
+                    {
+                        <MudAlert Severity="Severity.Error" ShowCloseIcon="true"
+                                  CloseIconClicked="@(() => _error = null)">
+                            @_error
+                        </MudAlert>
+                    }
+
+                    @if (_company is null && _error is null && !_loading)
+                    {
+                        <MudPaper Class="workbench-panel empty-state" Elevation="0">
+                            <MudText Typo="Typo.h5" GutterBottom="true">No result yet</MudText>
+                            <MudText Typo="Typo.body2">Run the probe to inspect the returned company model.</MudText>
+                        </MudPaper>
+                    }
+
+                    @if (_company is not null)
+                    {
+                        <MudPaper Class="workbench-panel" Elevation="0">
+                            <MudStack Spacing="3">
+                                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                                    <MudText Typo="Typo.h5">Result</MudText>
+                                    <MudChip T="string" Variant="Variant.Outlined" Color="Color.Primary">@_company.Currency</MudChip>
+                                    <MudChip T="string" Variant="Variant.Outlined" Color="Color.Secondary">@_company.Type</MudChip>
+                                </MudStack>
+
+                                <MudGrid Spacing="2">
+                                    <MudItem xs="12" sm="6">
+                                        <MudPaper Class="probe-card" Elevation="0">
+                                            <MudText Typo="Typo.caption">Name</MudText>
+                                            <MudText Typo="Typo.subtitle1">@_company.Name</MudText>
+                                        </MudPaper>
+                                    </MudItem>
+                                    <MudItem xs="12" sm="6">
+                                        <MudPaper Class="probe-card" Elevation="0">
+                                            <MudText Typo="Typo.caption">Subdomain</MudText>
+                                            <MudText Typo="Typo.subtitle1">@_company.Subdomain</MudText>
+                                        </MudPaper>
+                                    </MudItem>
+                                    <MudItem xs="12" sm="6">
+                                        <MudPaper Class="probe-card" Elevation="0">
+                                            <MudText Typo="Typo.caption">Registration No.</MudText>
+                                            <MudText Typo="Typo.subtitle1">@ValueOrFallback(_company.CompanyRegistrationNumber)</MudText>
+                                        </MudPaper>
+                                    </MudItem>
+                                    <MudItem xs="12" sm="6">
+                                        <MudPaper Class="probe-card" Elevation="0">
+                                            <MudText Typo="Typo.caption">Sales Tax Status</MudText>
+                                            <MudText Typo="Typo.subtitle1">@ValueOrFallback(_company.SalesTaxRegistrationStatus)</MudText>
+                                        </MudPaper>
+                                    </MudItem>
+                                    <MudItem xs="12" sm="6">
+                                        <MudPaper Class="probe-card" Elevation="0">
+                                            <MudText Typo="Typo.caption">Mileage Units</MudText>
+                                            <MudText Typo="Typo.subtitle1">@ValueOrFallback(_company.MileageUnits)</MudText>
+                                        </MudPaper>
+                                    </MudItem>
+                                    <MudItem xs="12" sm="6">
+                                        <MudPaper Class="probe-card" Elevation="0">
+                                            <MudText Typo="Typo.caption">Resource URL</MudText>
+                                            <MudText Typo="Typo.body2">@_company.Url</MudText>
+                                        </MudPaper>
+                                    </MudItem>
+                                </MudGrid>
+                            </MudStack>
+                        </MudPaper>
+                    }
+                </MudStack>
+            </MudItem>
+        </MudGrid>
+    }
+</MudContainer>
+
+@code {
+    private bool _loading;
+    private string? _error;
+    private FreeAgent.Client.Models.Company? _company;
+    private string EnvironmentName => Configuration["FreeAgent:Environment"] ?? "sandbox";
+    private const string SdkApiBaseUrl = "https://api.freeagent.com/v2/ (currently fixed in SDK)";
+
+    private async Task FetchCompanyAsync()
+    {
+        var token = TokenStore.GetToken();
+        if (token is null)
+        {
+            NavigationManager.NavigateTo("/");
+            return;
+        }
+
+        _loading = true;
+        _error = null;
+        _company = null;
+
+        try
+        {
+            using var client = OAuthService.CreateFreeAgentClient(token);
+            _company = await client.Company.GetCompanyAsync();
+        }
+        catch (FreeAgentApiException ex)
+        {
+            _error = $"API error: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            _error = $"Unexpected error: {ex.Message}";
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private static string ValueOrFallback(string? value) => string.IsNullOrWhiteSpace(value) ? "Not returned" : value;
+}

--- a/samples/FreeAgent.Client.Sample/Components/Pages/Error.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Pages/Error.razor
@@ -1,0 +1,12 @@
+@page "/Error"
+@using Microsoft.AspNetCore.Components.Web
+
+<PageTitle>Error — FreeAgent SDK Sample</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-6">
+    <MudAlert Severity="Severity.Error" Class="mb-4">
+        An unexpected error occurred.
+    </MudAlert>
+    <MudButton Variant="Variant.Outlined" Href="/"
+               StartIcon="@Icons.Material.Filled.Home">Return home</MudButton>
+</MudContainer>

--- a/samples/FreeAgent.Client.Sample/Components/Pages/Home.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Pages/Home.razor
@@ -1,0 +1,181 @@
+@page "/"
+@inject TokenStore TokenStore
+@inject OAuthService OAuthService
+@inject NavigationManager NavigationManager
+@inject IConfiguration Configuration
+
+<PageTitle>Home — FreeAgent SDK Sample</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.False" Class="sample-page">
+    <MudPaper Class="hero-panel" Elevation="0">
+        <MudGrid Spacing="3">
+            <MudItem xs="12" md="8">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.overline" Class="section-kicker">Sample application</MudText>
+                    <MudText Typo="Typo.h3">Validate OAuth and exercise SDK calls without leaving the repo.</MudText>
+                    <MudText Typo="Typo.body1" Class="hero-copy">
+                        This app is the local workbench for FreeAgent.NET development. It exposes the current SDK surface,
+                        shows connection state clearly, and gives contributors a safe place to verify new API calls as they land.
+                    </MudText>
+                    <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                        <MudChip T="string" Variant="Variant.Outlined" Color="Color.Primary" Icon="@Icons.Material.Filled.Security">OAuth redirect flow</MudChip>
+                        <MudChip T="string" Variant="Variant.Outlined" Color="Color.Secondary" Icon="@Icons.Material.Filled.Api">SDK-backed requests</MudChip>
+                        <MudChip T="string" Variant="Variant.Outlined" Color="Color.Info" Icon="@Icons.Material.Filled.Handyman">Contributor-friendly</MudChip>
+                    </MudStack>
+                </MudStack>
+            </MudItem>
+            <MudItem xs="12" md="4">
+                <MudPaper Class="status-panel" Elevation="0">
+                    <MudStack Spacing="2">
+                        <MudText Typo="Typo.subtitle1">Session status</MudText>
+                        <MudChip T="string"
+                                 Color="@(TokenStore.IsConnected ? Color.Success : Color.Default)"
+                                 Variant="Variant.Filled"
+                                 Icon="@(TokenStore.IsConnected ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.RadioButtonUnchecked)">
+                            @(TokenStore.IsConnected ? "Connected" : "Not connected")
+                        </MudChip>
+                        <MudText Typo="Typo.body2">Configured environment: <strong>@EnvironmentName</strong></MudText>
+                        <MudText Typo="Typo.body2">SDK API target: <strong>@SdkApiTarget</strong></MudText>
+                        <MudText Typo="Typo.body2">Redirect URI: <strong>@RedirectUri</strong></MudText>
+                    </MudStack>
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
+
+    @if (_authError is not null)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-4" ShowCloseIcon="true"
+                  CloseIconClicked="@(() => _authError = null)">
+            @_authError
+        </MudAlert>
+    }
+
+    <MudGrid Spacing="3" Class="mt-1">
+        <MudItem xs="12" md="7">
+            <MudPaper Class="workbench-panel" Elevation="0">
+                <MudStack Spacing="3">
+                    <MudText Typo="Typo.h5">Connection control</MudText>
+
+                    @if (TokenStore.IsConnected)
+                    {
+                        <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Outlined">
+                            Active OAuth session stored in memory for this app process.
+                        </MudAlert>
+
+                        @if (_token is not null)
+                        {
+                            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                                <MudIcon Icon="@Icons.Material.Filled.AccessTime" Size="Size.Small" />
+                                @if (_token.IsExpired)
+                                {
+                                    <MudText Typo="Typo.body2" Color="Color.Error">Token has expired. Disconnect and reconnect.</MudText>
+                                }
+                                else if (_token.IsExpiringSoon)
+                                {
+                                    <MudText Typo="Typo.body2" Color="Color.Warning">Token is expiring soon. The SDK will attempt automatic refresh.</MudText>
+                                }
+                                else
+                                {
+                                    <MudText Typo="Typo.body2">Token expires in approximately @ExpiresInMinutes minutes.</MudText>
+                                }
+                            </MudStack>
+                        }
+
+                        <MudStack Row="true" Spacing="2">
+                            <MudButton Variant="Variant.Outlined" Color="Color.Error"
+                                       StartIcon="@Icons.Material.Filled.LinkOff"
+                                       OnClick="Disconnect">Disconnect</MudButton>
+                            <MudButton Variant="Variant.Text" Color="Color.Primary"
+                                       Href="/company"
+                                       StartIcon="@Icons.Material.Filled.ArrowForward">Open company probe</MudButton>
+                        </MudStack>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2">
+                            Start the OAuth flow to connect a local developer session to FreeAgent.
+                            The app redirects to FreeAgent, handles the callback, and stores the token in memory.
+                        </MudText>
+
+                        @if (!OAuthService.IsConfigured)
+                        {
+                            <MudAlert Severity="Severity.Warning" Dense="true">
+                                Credentials are not configured. See <code>samples/README.md</code> for the user-secrets setup.
+                            </MudAlert>
+                        }
+
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Link"
+                                   Disabled="@(!OAuthService.IsConfigured)"
+                                   OnClick="Connect">
+                            Connect to FreeAgent
+                        </MudButton>
+                    }
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="5">
+            <MudPaper Class="workbench-panel" Elevation="0">
+                <MudStack Spacing="3">
+                    <MudText Typo="Typo.h5">Included probe</MudText>
+                    <MudText Typo="Typo.body2">The current sample ships with one implemented API check.</MudText>
+                    <MudPaper Class="probe-card" Elevation="0">
+                        <MudStack Spacing="1">
+                            <MudText Typo="Typo.subtitle1">Company</MudText>
+                            <MudText Typo="Typo.body2">Calls <code>CompanyService.GetCompanyAsync()</code> and renders the returned model.</MudText>
+                            <MudButton Variant="Variant.Text" Color="Color.Primary"
+                                       Href="/company"
+                                       StartIcon="@Icons.Material.Filled.Business">Open probe</MudButton>
+                        </MudStack>
+                    </MudPaper>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+</MudContainer>
+
+@code {
+    [SupplyParameterFromQuery(Name = "auth_error")]
+    private string? AuthErrorParam { get; set; }
+
+    private OAuthTokenResponse? _token;
+    private string? _authError;
+
+    private string EnvironmentName => Configuration["FreeAgent:Environment"] ?? "sandbox";
+    private const string SdkApiTarget = "https://api.freeagent.com/v2/ (currently fixed in SDK)";
+    private string RedirectUri => Configuration["FreeAgent:RedirectUri"] ?? "https://localhost:5001/oauth/callback";
+
+    private int ExpiresInMinutes =>
+        _token is null
+            ? 0
+            : Math.Max(0, (int)(_token.IssuedAt.AddSeconds(_token.ExpiresIn) - DateTime.UtcNow).TotalMinutes);
+
+    protected override void OnInitialized()
+    {
+        _token = TokenStore.GetToken();
+
+        _authError = AuthErrorParam switch
+        {
+            "invalid_state" => "Authentication failed: invalid state parameter. Please try connecting again.",
+            "missing_params" => "Authentication failed: missing parameters in the FreeAgent callback.",
+            "access_denied" => "Access denied. You did not approve the FreeAgent authorization request.",
+            { Length: > 0 } msg => $"Authentication failed: {msg}",
+            _ => null
+        };
+    }
+
+    private void Connect()
+    {
+        var state = TokenStore.GenerateAndStorePendingState();
+        var url = OAuthService.BuildAuthorizationUrl(state);
+        NavigationManager.NavigateTo(url, forceLoad: true);
+    }
+
+    private void Disconnect()
+    {
+        TokenStore.ClearToken();
+        NavigationManager.NavigateTo("/", forceLoad: false);
+    }
+}

--- a/samples/FreeAgent.Client.Sample/Components/Routes.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Routes.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/samples/FreeAgent.Client.Sample/Components/_Imports.razor
+++ b/samples/FreeAgent.Client.Sample/Components/_Imports.razor
@@ -1,0 +1,16 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using FreeAgent.Client
+@using FreeAgent.Client.Authentication
+@using FreeAgent.Client.Http
+@using FreeAgent.Client.Models
+@using FreeAgent.Client.Sample
+@using FreeAgent.Client.Sample.Components
+@using FreeAgent.Client.Sample.Components.Layout
+@using FreeAgent.Client.Sample.Services
+@using MudBlazor

--- a/samples/FreeAgent.Client.Sample/FreeAgent.Client.Sample.csproj
+++ b/samples/FreeAgent.Client.Sample/FreeAgent.Client.Sample.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <UserSecretsId>freeagent-client-sample-v1</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MudBlazor" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FreeAgent.Client\FreeAgent.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/FreeAgent.Client.Sample/Program.cs
+++ b/samples/FreeAgent.Client.Sample/Program.cs
@@ -14,6 +14,9 @@ builder.Services.AddMudServices(config =>
     config.SnackbarConfiguration.PreventDuplicates = false;
 });
 
+// NOTE: TokenStore and OAuthService are registered as singletons.
+// This sample is intended for local, single-user development use only.
+// In a multi-user scenario, tokens would be shared across all circuits/sessions.
 builder.Services.AddSingleton<TokenStore>();
 builder.Services.AddSingleton<OAuthService>();
 
@@ -62,7 +65,18 @@ app.MapGet("/oauth/callback", async (
     }
     catch (FreeAgentOAuthException ex)
     {
-        return Results.Redirect($"/?auth_error={Uri.EscapeDataString(ex.Message)}");
+        app.Logger.LogWarning(ex, "OAuth token exchange rejected by FreeAgent.");
+        return Results.Redirect("/?auth_error=token_exchange_failed");
+    }
+    catch (HttpRequestException ex)
+    {
+        app.Logger.LogError(ex, "Network error during OAuth token exchange.");
+        return Results.Redirect("/?auth_error=network_error");
+    }
+    catch (Exception ex)
+    {
+        app.Logger.LogError(ex, "Unexpected error during OAuth token exchange.");
+        return Results.Redirect("/?auth_error=unexpected_error");
     }
 
     return Results.Redirect("/");

--- a/samples/FreeAgent.Client.Sample/Program.cs
+++ b/samples/FreeAgent.Client.Sample/Program.cs
@@ -1,0 +1,74 @@
+using FreeAgent.Client.Authentication;
+using FreeAgent.Client.Sample.Components;
+using FreeAgent.Client.Sample.Services;
+using MudBlazor.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+builder.Services.AddMudServices(config =>
+{
+    config.SnackbarConfiguration.PositionClass = MudBlazor.Defaults.Classes.Position.BottomRight;
+    config.SnackbarConfiguration.PreventDuplicates = false;
+});
+
+builder.Services.AddSingleton<TokenStore>();
+builder.Services.AddSingleton<OAuthService>();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseAntiforgery();
+
+app.MapStaticAssets();
+
+// OAuth authorization callback — FreeAgent redirects here after the user approves or denies the app.
+app.MapGet("/oauth/callback", async (
+    string? code,
+    string? state,
+    string? error,
+    TokenStore tokenStore,
+    OAuthService oauthService) =>
+{
+    // FreeAgent returned an error (e.g. user denied access)
+    if (!string.IsNullOrEmpty(error))
+    {
+        return Results.Redirect($"/?auth_error={Uri.EscapeDataString(error)}");
+    }
+
+    if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
+    {
+        return Results.Redirect("/?auth_error=missing_params");
+    }
+
+    // CSRF check
+    if (!tokenStore.ValidateAndClearState(state))
+    {
+        return Results.Redirect("/?auth_error=invalid_state");
+    }
+
+    try
+    {
+        var token = await oauthService.ExchangeCodeAsync(code);
+        tokenStore.SetToken(token);
+    }
+    catch (FreeAgentOAuthException ex)
+    {
+        return Results.Redirect($"/?auth_error={Uri.EscapeDataString(ex.Message)}");
+    }
+
+    return Results.Redirect("/");
+});
+
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/samples/FreeAgent.Client.Sample/Program.cs
+++ b/samples/FreeAgent.Client.Sample/Program.cs
@@ -65,17 +65,17 @@ app.MapGet("/oauth/callback", async (
     }
     catch (FreeAgentOAuthException ex)
     {
-        app.Logger.LogWarning(ex, "OAuth token exchange rejected by FreeAgent.");
+        Log.OAuthRejected(app.Logger, ex);
         return Results.Redirect("/?auth_error=token_exchange_failed");
     }
     catch (HttpRequestException ex)
     {
-        app.Logger.LogError(ex, "Network error during OAuth token exchange.");
+        Log.OAuthNetworkError(app.Logger, ex);
         return Results.Redirect("/?auth_error=network_error");
     }
     catch (Exception ex)
     {
-        app.Logger.LogError(ex, "Unexpected error during OAuth token exchange.");
+        Log.OAuthUnexpectedError(app.Logger, ex);
         return Results.Redirect("/?auth_error=unexpected_error");
     }
 
@@ -86,3 +86,15 @@ app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
 app.Run();
+
+static partial class Log
+{
+    [LoggerMessage(Level = LogLevel.Warning, Message = "OAuth token exchange rejected by FreeAgent.")]
+    public static partial void OAuthRejected(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Network error during OAuth token exchange.")]
+    public static partial void OAuthNetworkError(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Unexpected error during OAuth token exchange.")]
+    public static partial void OAuthUnexpectedError(ILogger logger, Exception ex);
+}

--- a/samples/FreeAgent.Client.Sample/Properties/launchSettings.json
+++ b/samples/FreeAgent.Client.Sample/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/FreeAgent.Client.Sample/Services/OAuthService.cs
+++ b/samples/FreeAgent.Client.Sample/Services/OAuthService.cs
@@ -32,9 +32,9 @@ public sealed class OAuthService : IDisposable
     /// Returns <c>true</c> when all required OAuth credentials are present in configuration.
     /// </summary>
     public bool IsConfigured =>
-        !string.IsNullOrEmpty(_clientId) &&
-        !string.IsNullOrEmpty(_clientSecret) &&
-        !string.IsNullOrEmpty(_redirectUri);
+        !string.IsNullOrWhiteSpace(_clientId) &&
+        !string.IsNullOrWhiteSpace(_clientSecret) &&
+        !string.IsNullOrWhiteSpace(_redirectUri);
 
     /// <summary>
     /// Builds the FreeAgent OAuth authorization URL including the CSRF state parameter.
@@ -69,11 +69,6 @@ public sealed class OAuthService : IDisposable
 
     private FreeAgentOAuthClient GetOrCreateOAuthClient()
     {
-        if (_oauthClient is not null)
-        {
-            return _oauthClient;
-        }
-
         lock (_clientLock)
         {
             return _oauthClient ??= new FreeAgentOAuthClient(_clientId, _clientSecret, _redirectUri);

--- a/samples/FreeAgent.Client.Sample/Services/OAuthService.cs
+++ b/samples/FreeAgent.Client.Sample/Services/OAuthService.cs
@@ -1,0 +1,103 @@
+using FreeAgent.Client.Authentication;
+
+namespace FreeAgent.Client.Sample.Services;
+
+/// <summary>
+/// Wraps <see cref="FreeAgentOAuthClient"/> and provides authorization URL generation,
+/// authorization code exchange, and <see cref="FreeAgentClient"/> creation with automatic token refresh.
+/// </summary>
+public sealed class OAuthService : IDisposable
+{
+    private readonly string _clientId;
+    private readonly string _clientSecret;
+    private readonly string _redirectUri;
+    private FreeAgentOAuthClient? _oauthClient;
+    private readonly Lock _clientLock = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes the service from application configuration.
+    /// Expects <c>FreeAgent:ClientId</c>, <c>FreeAgent:ClientSecret</c>, and <c>FreeAgent:RedirectUri</c> keys.
+    /// </summary>
+    public OAuthService(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        var section = configuration.GetSection("FreeAgent");
+        _clientId = section["ClientId"] ?? string.Empty;
+        _clientSecret = section["ClientSecret"] ?? string.Empty;
+        _redirectUri = section["RedirectUri"] ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when all required OAuth credentials are present in configuration.
+    /// </summary>
+    public bool IsConfigured =>
+        !string.IsNullOrEmpty(_clientId) &&
+        !string.IsNullOrEmpty(_clientSecret) &&
+        !string.IsNullOrEmpty(_redirectUri);
+
+    /// <summary>
+    /// Builds the FreeAgent OAuth authorization URL including the CSRF state parameter.
+    /// </summary>
+    public string BuildAuthorizationUrl(string state)
+    {
+        EnsureConfigured();
+        return GetOrCreateOAuthClient().GetAuthorizationUrl(state);
+    }
+
+    /// <summary>
+    /// Exchanges an authorization code for an <see cref="OAuthTokenResponse"/>.
+    /// </summary>
+    public async Task<OAuthTokenResponse> ExchangeCodeAsync(string code, CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        return await GetOrCreateOAuthClient()
+            .ExchangeCodeForTokenAsync(code, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="FreeAgentClient"/> configured for automatic token refresh.
+    /// The caller is responsible for disposing the returned client.
+    /// </summary>
+    public FreeAgentClient CreateFreeAgentClient(OAuthTokenResponse token)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        EnsureConfigured();
+        return new FreeAgentClient(GetOrCreateOAuthClient(), token);
+    }
+
+    private FreeAgentOAuthClient GetOrCreateOAuthClient()
+    {
+        if (_oauthClient is not null)
+        {
+            return _oauthClient;
+        }
+
+        lock (_clientLock)
+        {
+            return _oauthClient ??= new FreeAgentOAuthClient(_clientId, _clientSecret, _redirectUri);
+        }
+    }
+
+    private void EnsureConfigured()
+    {
+        if (!IsConfigured)
+        {
+            throw new InvalidOperationException(
+                "FreeAgent OAuth credentials are not configured. " +
+                "Set FreeAgent:ClientId, FreeAgent:ClientSecret, and FreeAgent:RedirectUri " +
+                "using dotnet user-secrets. See samples/README.md for instructions.");
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _oauthClient?.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/samples/FreeAgent.Client.Sample/Services/TokenStore.cs
+++ b/samples/FreeAgent.Client.Sample/Services/TokenStore.cs
@@ -1,0 +1,93 @@
+using FreeAgent.Client.Authentication;
+
+namespace FreeAgent.Client.Sample.Services;
+
+/// <summary>
+/// Thread-safe in-memory store for the active FreeAgent OAuth token.
+/// Token lifetime is scoped to the application process; tokens are lost on restart.
+/// </summary>
+public sealed class TokenStore
+{
+    private readonly Lock _lock = new();
+    private OAuthTokenResponse? _token;
+    private string? _pendingState;
+
+    /// <summary>
+    /// Returns the stored token, or <c>null</c> if not connected.
+    /// </summary>
+    public OAuthTokenResponse? GetToken()
+    {
+        lock (_lock)
+        {
+            return _token;
+        }
+    }
+
+    /// <summary>
+    /// Stores the token received from a successful OAuth exchange.
+    /// </summary>
+    public void SetToken(OAuthTokenResponse token)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        lock (_lock)
+        {
+            _token = token;
+        }
+    }
+
+    /// <summary>
+    /// Clears the stored token (disconnect).
+    /// </summary>
+    public void ClearToken()
+    {
+        lock (_lock)
+        {
+            _token = null;
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when a token is stored and the user is considered connected.
+    /// </summary>
+    public bool IsConnected
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _token is not null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generates a cryptographically random state value, stores it for CSRF validation,
+    /// and returns it for inclusion in the OAuth authorization URL.
+    /// </summary>
+    public string GenerateAndStorePendingState()
+    {
+        var state = Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32));
+        lock (_lock)
+        {
+            _pendingState = state;
+        }
+        return state;
+    }
+
+    /// <summary>
+    /// Validates the state returned from the OAuth callback against the stored pending state.
+    /// Clears the stored state regardless of outcome to prevent replay.
+    /// </summary>
+    /// <returns><c>true</c> if the state matches; <c>false</c> otherwise.</returns>
+    public bool ValidateAndClearState(string state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        lock (_lock)
+        {
+            var valid = _pendingState is not null &&
+                        string.Equals(_pendingState, state, StringComparison.Ordinal);
+            _pendingState = null;
+            return valid;
+        }
+    }
+}

--- a/samples/FreeAgent.Client.Sample/appsettings.Development.json
+++ b/samples/FreeAgent.Client.Sample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/FreeAgent.Client.Sample/appsettings.json
+++ b/samples/FreeAgent.Client.Sample/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "FreeAgent": {
+    "ClientId": "",
+    "ClientSecret": "",
+    "RedirectUri": "https://localhost:5001/oauth/callback",
+    "Environment": "sandbox"
+  }
+}

--- a/samples/FreeAgent.Client.Sample/wwwroot/app.css
+++ b/samples/FreeAgent.Client.Sample/wwwroot/app.css
@@ -1,0 +1,111 @@
+:root {
+    color-scheme: light;
+    --sample-bg: linear-gradient(180deg, #f7faf7 0%, #eef3ef 52%, #e8efea 100%);
+    --panel-border: rgba(15, 23, 42, 0.08);
+    --panel-shadow: 0 20px 60px rgba(23, 39, 32, 0.08);
+    --hero-shadow: 0 30px 80px rgba(15, 118, 110, 0.12);
+}
+
+html,
+body {
+    min-height: 100%;
+    margin: 0;
+    font-family: 'Roboto', sans-serif;
+    background: var(--sample-bg);
+}
+
+.sample-appbar {
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(15, 23, 42, 0.07);
+}
+
+.shell-subtitle {
+    color: #567069;
+}
+
+.sample-drawer {
+    border-right: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.drawer-header {
+    padding: 1.5rem 1.25rem 1rem;
+}
+
+.drawer-label,
+.section-kicker {
+    letter-spacing: 0.14em;
+    color: #0f766e;
+    font-weight: 700;
+}
+
+.drawer-copy,
+.hero-copy {
+    color: #50615b;
+}
+
+.sample-main {
+    padding: 5.5rem 1.5rem 2rem;
+}
+
+.sample-page {
+    max-width: 1200px;
+}
+
+.hero-panel,
+.workbench-panel,
+.status-panel,
+.probe-card {
+    border: 1px solid var(--panel-border);
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.82);
+}
+
+.hero-panel {
+    padding: 2rem;
+    box-shadow: var(--hero-shadow);
+    margin-bottom: 1.5rem;
+}
+
+.hero-panel.compact {
+    padding: 1.75rem;
+}
+
+.status-panel {
+    padding: 1.25rem;
+    box-shadow: var(--panel-shadow);
+}
+
+.workbench-panel {
+    padding: 1.5rem;
+    box-shadow: var(--panel-shadow);
+}
+
+.probe-card {
+    padding: 1rem;
+    background: rgba(248, 250, 248, 0.95);
+}
+
+.empty-state {
+    min-height: 12rem;
+    display: flex;
+    align-items: center;
+}
+
+code {
+    display: inline-block;
+    padding: 0.1rem 0.35rem;
+    border-radius: 8px;
+    background: rgba(15, 118, 110, 0.08);
+}
+
+@media (max-width: 960px) {
+    .sample-main {
+        padding: 5rem 0.75rem 1rem;
+    }
+
+    .hero-panel,
+    .workbench-panel,
+    .status-panel {
+        border-radius: 18px;
+    }
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,88 @@
+# FreeAgent SDK Sample App
+
+An interactive Blazor Server app for testing the `FreeAgent.Client` SDK.
+Use it to exercise SDK calls against the FreeAgent API as new services are added to the codebase.
+
+---
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- A FreeAgent developer account and registered OAuth app
+  - Production apps: <https://dev.freeagent.com>
+  - Sandbox apps: <https://dev.sandbox.freeagent.com>
+
+---
+
+## 1. Register a FreeAgent OAuth App
+
+1. Sign in to the appropriate FreeAgent developer portal (sandbox recommended for development).
+2. Create a new application.
+3. Set the **OAuth Redirect URI** to exactly:
+
+   ```
+   https://localhost:5001/oauth/callback
+   ```
+
+   > **Important:** The redirect URI must match exactly — including the scheme (`https`), host (`localhost`), port (`:5001`), and path (`/oauth/callback`). A mismatch will cause the authorization flow to fail.
+
+4. Note your **OAuth identifier** and **OAuth secret**.
+
+---
+
+## 2. Configure Credentials via User Secrets
+
+Never put credentials in `appsettings.json`. Use .NET user secrets instead:
+
+```bash
+cd samples/FreeAgent.Client.Sample
+
+dotnet user-secrets set "FreeAgent:ClientId"     "<your-client-id>"
+dotnet user-secrets set "FreeAgent:ClientSecret" "<your-client-secret>"
+```
+
+The `FreeAgent:RedirectUri` value in `appsettings.json` defaults to `https://localhost:5001/oauth/callback` and should match what you registered in step 1. Override it via user secrets if you use a different port:
+
+```bash
+dotnet user-secrets set "FreeAgent:RedirectUri" "https://localhost:5001/oauth/callback"
+```
+
+---
+
+## 3. Run the App
+
+```bash
+cd samples/FreeAgent.Client.Sample
+dotnet run
+```
+
+The app starts at `https://localhost:5001`. Your browser may show a certificate warning for the local development certificate; accept it, or run `dotnet dev-certs https --trust` first.
+
+---
+
+## 4. Authorize the App
+
+1. Navigate to <https://localhost:5001>.
+2. Click **Connect to FreeAgent**.
+3. You are redirected to FreeAgent's authorization page — approve the app.
+4. FreeAgent redirects back to `https://localhost:5001/oauth/callback`.
+5. The app exchanges the code for a token and shows **Connected** in the header.
+
+---
+
+## 5. Test SDK Calls
+
+| Page | SDK call tested |
+|------|----------------|
+| [/company](https://localhost:5001/company) | `CompanyService.GetCompanyAsync()` |
+
+Additional pages will be added as new services are implemented.
+
+---
+
+## Notes for Contributors
+
+- **Token lifetime:** The token is held in memory. It is lost when the app restarts; reconnect to get a new one. The SDK handles automatic token refresh within an active session.
+- **Sandbox vs production:** `appsettings.json` has a `FreeAgent:Environment` setting (default `sandbox`) ready for when the SDK adds configurable environment support (see [issue #20](https://github.com/markheydon/freeagent-dotnet/issues/20)).
+- **Port:** The sample uses port `5001` (HTTPS). If you change it in `Properties/launchSettings.json`, update the redirect URI in both your FreeAgent app registration and your user secrets.
+- **Do not commit credentials.** `appsettings.json` contains only empty placeholders. User secrets are stored outside the repository in your OS user profile.


### PR DESCRIPTION
## Summary
- Add a new Blazor Server sample app under `samples/FreeAgent.Client.Sample` as an interactive SDK workbench
- Implement full OAuth flow for local testing: connect, callback handling, code exchange, and in-memory token storage
- Add a Company probe page that exercises `CompanyService.GetCompanyAsync()` and displays typed model results
- Add MudBlazor-based UI shell and component pages for contributor-focused testing workflows
- Add sample setup docs in `samples/README.md` and include project in `FreeAgent.slnx`
- Add MudBlazor central package version in `Directory.Packages.props`

## Details
- OAuth callback endpoint mapped in sample `Program.cs` (`/oauth/callback`) with state validation
- `TokenStore` + `OAuthService` added for session token handling and FreeAgent client creation
- UI updated to clearly distinguish configured environment vs actual SDK API target
- MudBlazor static assets wired using Blazor Web App asset pattern

## Validation
- `dotnet build samples/FreeAgent.Client.Sample/FreeAgent.Client.Sample.csproj`
- Existing tests remained green during development (`FreeAgent.Client.Tests`)

## Follow-up / Known limitation
- SDK currently targets production endpoints by default; configurable sandbox/production endpoint support is tracked in #20

## Risk notes
- No changes to existing SDK API behavior; sample app is additive
- Token persistence across restarts intentionally out of scope for this sample