### PR TITLE
Add tag/version validation step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,19 @@ jobs:
         with:
           dotnet-version: '10.x'
 
+      - name: Validate tag matches package version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          # Strip leading 'v' from tag (v0.1.0-alpha.1 → 0.1.0-alpha.1)
+          TAG_VERSION="${TAG#v}"
+          CSPROJ_VERSION=$(grep -oP '(?<=<Version>)[^<]+' src/FreeAgent.Client/FreeAgent.Client.csproj)
+          echo "Tag version:    ${TAG_VERSION}"
+          echo "csproj version: ${CSPROJ_VERSION}"
+          if [[ "${TAG_VERSION}" != "${CSPROJ_VERSION}" ]]; then
+            echo "::error::Tag version '${TAG_VERSION}' does not match csproj version '${CSPROJ_VERSION}'. Update <Version> in FreeAgent.Client.csproj before tagging."
+            exit 1
+          fi
+
       - name: Restore
         run: dotnet restore FreeAgent.slnx
 


### PR DESCRIPTION
## Summary

Adds the one missing acceptance criterion from issue #7: a version/package metadata validation step in the release workflow.

## Changes

- **`.github/workflows/release.yml`**: new step between "Setup .NET" and "Restore" that extracts `<Version>` from `src/FreeAgent.Client/FreeAgent.Client.csproj` and compares it to the pushed Git tag (stripped of leading `v`). If they don't match, the workflow fails fast with a clear error message before any build or publish step runs.

## Why

PR #18 delivered the release workflow, versioning policy, and runbook, but the acceptance criterion _"Version/package metadata validation step added"_ was not covered. This closes that gap.

Closes #7

## Impact

- No changes to public API surface.
- No changes to CI workflow.
- Adds a pre-build gate: releases will fail early and clearly if the tag and `.csproj` version are out of sync.