### PR TITLE
Configurable FreeAgent environment (production/sandbox) across SDK and sample

### DIFF
--- a/samples/FreeAgent.Client.Sample/Components/Pages/Company.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Pages/Company.razor
@@ -173,7 +173,7 @@
 
         try
         {
-            using var client = OAuthService.CreateFreeAgentClient(token);
+            using var client = OAuthService.CreateFreeAgentClient(token, TokenStore.ConnectedEnvironment);
             _company = await client.Company.GetCompanyAsync();
         }
         catch (FreeAgentApiException ex)

--- a/samples/FreeAgent.Client.Sample/Components/Pages/Company.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Pages/Company.razor
@@ -2,7 +2,6 @@
 @inject TokenStore TokenStore
 @inject OAuthService OAuthService
 @inject NavigationManager NavigationManager
-@inject IConfiguration Configuration
 
 <PageTitle>Company — FreeAgent SDK Sample</PageTitle>
 
@@ -151,8 +150,13 @@
     private bool _loading;
     private string? _error;
     private FreeAgent.Client.Models.Company? _company;
-    private string EnvironmentName => Configuration["FreeAgent:Environment"] ?? "sandbox";
-    private const string SdkApiBaseUrl = "https://api.freeagent.com/v2/ (currently fixed in SDK)";
+
+    private FreeAgentEnvironment ActiveEnvironment =>
+        TokenStore.IsConnected ? TokenStore.ConnectedEnvironment : OAuthService.SelectedEnvironment;
+
+    private string EnvironmentName => ActiveEnvironment.ToString();
+
+    private string SdkApiBaseUrl => FreeAgentEnvironmentEndpoints.GetApiBaseUrl(ActiveEnvironment);
 
     private async Task FetchCompanyAsync()
     {

--- a/samples/FreeAgent.Client.Sample/Components/Pages/Home.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Pages/Home.razor
@@ -63,6 +63,10 @@
                             Active OAuth session stored in memory for this app process.
                         </MudAlert>
 
+                        <MudChip T="string" Color="Color.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.Lock">
+                            Connected to @EnvironmentName
+                        </MudChip>
+
                         @if (_token is not null)
                         {
                             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
@@ -96,6 +100,20 @@
                         <MudText Typo="Typo.body2">
                             Start the OAuth flow to connect a local developer session to FreeAgent.
                             The app redirects to FreeAgent, handles the callback, and stores the token in memory.
+                        </MudText>
+
+                        <MudSelect T="FreeAgentEnvironment"
+                                   Label="FreeAgent environment"
+                                   Value="SelectedEnvironment"
+                                   ValueChanged="OnSelectedEnvironmentChanged"
+                                   Variant="Variant.Outlined"
+                                   Dense="true">
+                            <MudSelectItem T="FreeAgentEnvironment" Value="FreeAgentEnvironment.Production">Production</MudSelectItem>
+                            <MudSelectItem T="FreeAgentEnvironment" Value="FreeAgentEnvironment.Sandbox">Sandbox</MudSelectItem>
+                        </MudSelect>
+
+                        <MudText Typo="Typo.caption">
+                            Sandbox uses api.sandbox.freeagent.com and is safe for isolated testing.
                         </MudText>
 
                         @if (!OAuthService.IsConfigured)
@@ -143,8 +161,15 @@
     private OAuthTokenResponse? _token;
     private string? _authError;
 
-    private string EnvironmentName => Configuration["FreeAgent:Environment"] ?? "sandbox";
-    private const string SdkApiTarget = "https://api.freeagent.com/v2/ (currently fixed in SDK)";
+    private FreeAgentEnvironment ActiveEnvironment =>
+        TokenStore.IsConnected ? TokenStore.ConnectedEnvironment : OAuthService.SelectedEnvironment;
+
+    private FreeAgentEnvironment SelectedEnvironment => OAuthService.SelectedEnvironment;
+
+    private string EnvironmentName => ActiveEnvironment.ToString();
+
+    private string SdkApiTarget => FreeAgentEnvironmentEndpoints.GetApiBaseUrl(ActiveEnvironment);
+
     private string RedirectUri => Configuration["FreeAgent:RedirectUri"] ?? "https://localhost:5001/oauth/callback";
 
     private int ExpiresInMinutes =>
@@ -176,6 +201,12 @@
     private void Disconnect()
     {
         TokenStore.ClearToken();
+        _token = null;
         NavigationManager.NavigateTo("/", forceLoad: false);
+    }
+
+    private void OnSelectedEnvironmentChanged(FreeAgentEnvironment environment)
+    {
+        OAuthService.SelectedEnvironment = environment;
     }
 }

--- a/samples/FreeAgent.Client.Sample/Components/Pages/Home.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Pages/Home.razor
@@ -193,7 +193,7 @@
 
     private void Connect()
     {
-        var state = TokenStore.GenerateAndStorePendingState();
+        var state = TokenStore.GenerateAndStorePendingState(OAuthService.SelectedEnvironment);
         var url = OAuthService.BuildAuthorizationUrl(state);
         NavigationManager.NavigateTo(url, forceLoad: true);
     }

--- a/samples/FreeAgent.Client.Sample/Program.cs
+++ b/samples/FreeAgent.Client.Sample/Program.cs
@@ -61,7 +61,7 @@ app.MapGet("/oauth/callback", async (
     try
     {
         var token = await oauthService.ExchangeCodeAsync(code);
-        tokenStore.SetToken(token);
+        tokenStore.SetToken(token, oauthService.SelectedEnvironment);
     }
     catch (FreeAgentOAuthException ex)
     {

--- a/samples/FreeAgent.Client.Sample/Program.cs
+++ b/samples/FreeAgent.Client.Sample/Program.cs
@@ -53,7 +53,7 @@ app.MapGet("/oauth/callback", async (
     }
 
     // CSRF check
-    if (!tokenStore.ValidateAndClearState(state))
+    if (!tokenStore.ValidateAndClearState(state, out var pendingEnvironment))
     {
         return Results.Redirect("/?auth_error=invalid_state");
     }
@@ -61,7 +61,7 @@ app.MapGet("/oauth/callback", async (
     try
     {
         var token = await oauthService.ExchangeCodeAsync(code);
-        tokenStore.SetToken(token, oauthService.SelectedEnvironment);
+        tokenStore.SetToken(token, pendingEnvironment);
     }
     catch (FreeAgentOAuthException ex)
     {

--- a/samples/FreeAgent.Client.Sample/Services/OAuthService.cs
+++ b/samples/FreeAgent.Client.Sample/Services/OAuthService.cs
@@ -1,3 +1,4 @@
+using FreeAgent.Client;
 using FreeAgent.Client.Authentication;
 
 namespace FreeAgent.Client.Sample.Services;
@@ -11,6 +12,7 @@ public sealed class OAuthService : IDisposable
     private readonly string _clientId;
     private readonly string _clientSecret;
     private readonly string _redirectUri;
+    private FreeAgentEnvironment _selectedEnvironment = FreeAgentEnvironment.Production;
     private FreeAgentOAuthClient? _oauthClient;
     private readonly Lock _clientLock = new();
     private bool _disposed;
@@ -26,6 +28,36 @@ public sealed class OAuthService : IDisposable
         _clientId = section["ClientId"] ?? string.Empty;
         _clientSecret = section["ClientSecret"] ?? string.Empty;
         _redirectUri = section["RedirectUri"] ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the selected FreeAgent API environment for the next OAuth connection attempt.
+    /// Changing this value resets the cached OAuth client so endpoint URLs stay in sync.
+    /// </summary>
+    public FreeAgentEnvironment SelectedEnvironment
+    {
+        get
+        {
+            lock (_clientLock)
+            {
+                return _selectedEnvironment;
+            }
+        }
+
+        set
+        {
+            lock (_clientLock)
+            {
+                if (_selectedEnvironment == value)
+                {
+                    return;
+                }
+
+                _selectedEnvironment = value;
+                _oauthClient?.Dispose();
+                _oauthClient = null;
+            }
+        }
     }
 
     /// <summary>
@@ -64,14 +96,16 @@ public sealed class OAuthService : IDisposable
     {
         ArgumentNullException.ThrowIfNull(token);
         EnsureConfigured();
-        return new FreeAgentClient(GetOrCreateOAuthClient(), token);
+
+        var oauthClient = GetOrCreateOAuthClient();
+        return new FreeAgentClient(oauthClient, token, SelectedEnvironment);
     }
 
     private FreeAgentOAuthClient GetOrCreateOAuthClient()
     {
         lock (_clientLock)
         {
-            return _oauthClient ??= new FreeAgentOAuthClient(_clientId, _clientSecret, _redirectUri);
+            return _oauthClient ??= new FreeAgentOAuthClient(_clientId, _clientSecret, _redirectUri, _selectedEnvironment);
         }
     }
 
@@ -91,7 +125,11 @@ public sealed class OAuthService : IDisposable
     {
         if (!_disposed)
         {
-            _oauthClient?.Dispose();
+            lock (_clientLock)
+            {
+                _oauthClient?.Dispose();
+                _oauthClient = null;
+            }
             _disposed = true;
         }
     }

--- a/samples/FreeAgent.Client.Sample/Services/OAuthService.cs
+++ b/samples/FreeAgent.Client.Sample/Services/OAuthService.cs
@@ -92,13 +92,13 @@ public sealed class OAuthService : IDisposable
     /// Creates a <see cref="FreeAgentClient"/> configured for automatic token refresh.
     /// The caller is responsible for disposing the returned client.
     /// </summary>
-    public FreeAgentClient CreateFreeAgentClient(OAuthTokenResponse token)
+    public FreeAgentClient CreateFreeAgentClient(OAuthTokenResponse token, FreeAgentEnvironment connectedEnvironment)
     {
         ArgumentNullException.ThrowIfNull(token);
         EnsureConfigured();
 
         var oauthClient = GetOrCreateOAuthClient();
-        return new FreeAgentClient(oauthClient, token, SelectedEnvironment);
+        return new FreeAgentClient(oauthClient, token, connectedEnvironment);
     }
 
     private FreeAgentOAuthClient GetOrCreateOAuthClient()

--- a/samples/FreeAgent.Client.Sample/Services/TokenStore.cs
+++ b/samples/FreeAgent.Client.Sample/Services/TokenStore.cs
@@ -13,6 +13,7 @@ public sealed class TokenStore
     private OAuthTokenResponse? _token;
     private FreeAgentEnvironment _connectedEnvironment = FreeAgentEnvironment.Production;
     private string? _pendingState;
+    private FreeAgentEnvironment _pendingEnvironment = FreeAgentEnvironment.Production;
 
     /// <summary>
     /// Returns the stored token, or <c>null</c> if not connected.
@@ -79,25 +80,32 @@ public sealed class TokenStore
     }
 
     /// <summary>
-    /// Generates a cryptographically random state value, stores it for CSRF validation,
-    /// and returns it for inclusion in the OAuth authorization URL.
+    /// Generates a cryptographically random state value, stores it together with the chosen
+    /// <paramref name="environment"/> for CSRF validation, and returns it for inclusion in
+    /// the OAuth authorization URL.
     /// </summary>
-    public string GenerateAndStorePendingState()
+    public string GenerateAndStorePendingState(FreeAgentEnvironment environment)
     {
         var state = Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32));
         lock (_lock)
         {
             _pendingState = state;
+            _pendingEnvironment = environment;
         }
         return state;
     }
 
     /// <summary>
     /// Validates the state returned from the OAuth callback against the stored pending state.
-    /// Clears the stored state regardless of outcome to prevent replay.
+    /// Clears the stored state and environment regardless of outcome to prevent replay.
     /// </summary>
+    /// <param name="state">The state value returned from the OAuth callback.</param>
+    /// <param name="pendingEnvironment">
+    /// When this method returns <c>true</c>, contains the environment that was selected
+    /// when the authorization URL was generated. When <c>false</c>, the value is undefined.
+    /// </param>
     /// <returns><c>true</c> if the state matches; <c>false</c> otherwise.</returns>
-    public bool ValidateAndClearState(string state)
+    public bool ValidateAndClearState(string state, out FreeAgentEnvironment pendingEnvironment)
     {
         ArgumentNullException.ThrowIfNull(state);
         lock (_lock)
@@ -105,6 +113,8 @@ public sealed class TokenStore
             var valid = _pendingState is not null &&
                         string.Equals(_pendingState, state, StringComparison.Ordinal);
             _pendingState = null;
+            pendingEnvironment = _pendingEnvironment;
+            _pendingEnvironment = FreeAgentEnvironment.Production;
             return valid;
         }
     }

--- a/samples/FreeAgent.Client.Sample/Services/TokenStore.cs
+++ b/samples/FreeAgent.Client.Sample/Services/TokenStore.cs
@@ -1,3 +1,4 @@
+using FreeAgent.Client;
 using FreeAgent.Client.Authentication;
 
 namespace FreeAgent.Client.Sample.Services;
@@ -10,6 +11,7 @@ public sealed class TokenStore
 {
     private readonly Lock _lock = new();
     private OAuthTokenResponse? _token;
+    private FreeAgentEnvironment _connectedEnvironment = FreeAgentEnvironment.Production;
     private string? _pendingState;
 
     /// <summary>
@@ -26,12 +28,13 @@ public sealed class TokenStore
     /// <summary>
     /// Stores the token received from a successful OAuth exchange.
     /// </summary>
-    public void SetToken(OAuthTokenResponse token)
+    public void SetToken(OAuthTokenResponse token, FreeAgentEnvironment environment)
     {
         ArgumentNullException.ThrowIfNull(token);
         lock (_lock)
         {
             _token = token;
+            _connectedEnvironment = environment;
         }
     }
 
@@ -43,6 +46,21 @@ public sealed class TokenStore
         lock (_lock)
         {
             _token = null;
+            _connectedEnvironment = FreeAgentEnvironment.Production;
+        }
+    }
+
+    /// <summary>
+    /// Returns the environment used for the active connection.
+    /// </summary>
+    public FreeAgentEnvironment ConnectedEnvironment
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _connectedEnvironment;
+            }
         }
     }
 

--- a/samples/FreeAgent.Client.Sample/appsettings.json
+++ b/samples/FreeAgent.Client.Sample/appsettings.json
@@ -9,7 +9,6 @@
   "FreeAgent": {
     "ClientId": "",
     "ClientSecret": "",
-    "RedirectUri": "https://localhost:5001/oauth/callback",
-    "Environment": "sandbox"
+    "RedirectUri": "https://localhost:5001/oauth/callback"
   }
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -83,6 +83,6 @@ Additional pages will be added as new services are implemented.
 ## Notes for Contributors
 
 - **Token lifetime:** The token is held in memory. It is lost when the app restarts; reconnect to get a new one. The SDK handles automatic token refresh within an active session.
-- **Sandbox vs production:** `appsettings.json` has a `FreeAgent:Environment` setting (default `sandbox`) ready for when the SDK adds configurable environment support (see [issue #20](https://github.com/markheydon/freeagent-dotnet/issues/20)).
+- **Sandbox vs production:** Choose the target environment from the Connect panel before starting OAuth. After connecting, disconnect to switch environments.
 - **Port:** The sample uses port `5001` (HTTPS). If you change it in `Properties/launchSettings.json`, update the redirect URI in both your FreeAgent app registration and your user secrets.
 - **Do not commit credentials.** `appsettings.json` contains only empty placeholders. User secrets are stored outside the repository in your OS user profile.

--- a/src/FreeAgent.Client/Authentication/FreeAgentOAuthClient.cs
+++ b/src/FreeAgent.Client/Authentication/FreeAgentOAuthClient.cs
@@ -12,8 +12,8 @@ public class FreeAgentOAuthClient : IDisposable
     private readonly bool _ownsHttpClient;
     private bool _disposed;
 
-    private const string AuthorizationEndpoint = "https://api.freeagent.com/v2/approve_app";
-    private const string TokenEndpoint = "https://api.freeagent.com/v2/token_endpoint";
+    private readonly string _authorizationEndpoint;
+    private readonly string _tokenEndpoint;
 
     // Cached to avoid allocating a new instance per call (CA1869)
     private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
@@ -27,13 +27,16 @@ public class FreeAgentOAuthClient : IDisposable
     /// <param name="clientId">OAuth client ID</param>
     /// <param name="clientSecret">OAuth client secret</param>
     /// <param name="redirectUri">OAuth redirect URI</param>
-    public FreeAgentOAuthClient(string clientId, string clientSecret, string redirectUri)
+    /// <param name="environment">Target API environment. Defaults to <see cref="FreeAgentEnvironment.Production"/>.</param>
+    public FreeAgentOAuthClient(string clientId, string clientSecret, string redirectUri, FreeAgentEnvironment environment = FreeAgentEnvironment.Production)
     {
         _clientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
         _clientSecret = clientSecret ?? throw new ArgumentNullException(nameof(clientSecret));
         _redirectUri = redirectUri ?? throw new ArgumentNullException(nameof(redirectUri));
         _httpClient = new HttpClient();
         _ownsHttpClient = true;
+        _authorizationEndpoint = FreeAgentEnvironmentEndpoints.GetOAuthAuthorizationEndpoint(environment);
+        _tokenEndpoint = FreeAgentEnvironmentEndpoints.GetOAuthTokenEndpoint(environment);
     }
 
     /// <summary>
@@ -43,13 +46,16 @@ public class FreeAgentOAuthClient : IDisposable
     /// <param name="clientSecret">OAuth client secret</param>
     /// <param name="redirectUri">OAuth redirect URI</param>
     /// <param name="httpClient">Custom HttpClient instance</param>
-    public FreeAgentOAuthClient(string clientId, string clientSecret, string redirectUri, HttpClient httpClient)
+    /// <param name="environment">Target API environment. Defaults to <see cref="FreeAgentEnvironment.Production"/>.</param>
+    public FreeAgentOAuthClient(string clientId, string clientSecret, string redirectUri, HttpClient httpClient, FreeAgentEnvironment environment = FreeAgentEnvironment.Production)
     {
         _clientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
         _clientSecret = clientSecret ?? throw new ArgumentNullException(nameof(clientSecret));
         _redirectUri = redirectUri ?? throw new ArgumentNullException(nameof(redirectUri));
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _ownsHttpClient = false;
+        _authorizationEndpoint = FreeAgentEnvironmentEndpoints.GetOAuthAuthorizationEndpoint(environment);
+        _tokenEndpoint = FreeAgentEnvironmentEndpoints.GetOAuthTokenEndpoint(environment);
     }
 
     /// <summary>
@@ -74,7 +80,7 @@ public class FreeAgentOAuthClient : IDisposable
         var queryString = string.Join("&", queryParams.Select(kvp =>
             $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}"));
 
-        return $"{AuthorizationEndpoint}?{queryString}";
+        return $"{_authorizationEndpoint}?{queryString}";
     }
 
     /// <summary>
@@ -129,7 +135,7 @@ public class FreeAgentOAuthClient : IDisposable
     private async Task<OAuthTokenResponse> RequestTokenAsync(Dictionary<string, string> requestData, CancellationToken cancellationToken)
     {
         using var content = new FormUrlEncodedContent(requestData);
-        using var response = await _httpClient.PostAsync(TokenEndpoint, content, cancellationToken);
+        using var response = await _httpClient.PostAsync(_tokenEndpoint, content, cancellationToken);
 
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 

--- a/src/FreeAgent.Client/FreeAgentClient.cs
+++ b/src/FreeAgent.Client/FreeAgentClient.cs
@@ -21,9 +21,10 @@ public class FreeAgentClient : IDisposable
     /// Initializes a new instance with an access token.
     /// </summary>
     /// <param name="accessToken">OAuth access token</param>
-    public FreeAgentClient(string accessToken)
+    /// <param name="environment">Target API environment. Defaults to <see cref="FreeAgentEnvironment.Production"/>.</param>
+    public FreeAgentClient(string accessToken, FreeAgentEnvironment environment = FreeAgentEnvironment.Production)
     {
-        _httpClient = new FreeAgentHttpClient(accessToken);
+        _httpClient = new FreeAgentHttpClient(accessToken, environment);
         Company = new CompanyService(_httpClient);
     }
 
@@ -32,9 +33,10 @@ public class FreeAgentClient : IDisposable
     /// </summary>
     /// <param name="oauthClient">OAuth client</param>
     /// <param name="token">OAuth token</param>
-    public FreeAgentClient(FreeAgentOAuthClient oauthClient, OAuthTokenResponse token)
+    /// <param name="environment">Target API environment. Defaults to <see cref="FreeAgentEnvironment.Production"/>.</param>
+    public FreeAgentClient(FreeAgentOAuthClient oauthClient, OAuthTokenResponse token, FreeAgentEnvironment environment = FreeAgentEnvironment.Production)
     {
-        _httpClient = new FreeAgentHttpClient(oauthClient, token);
+        _httpClient = new FreeAgentHttpClient(oauthClient, token, environment);
         Company = new CompanyService(_httpClient);
     }
 

--- a/src/FreeAgent.Client/FreeAgentEnvironment.cs
+++ b/src/FreeAgent.Client/FreeAgentEnvironment.cs
@@ -1,0 +1,18 @@
+namespace FreeAgent.Client;
+
+/// <summary>
+/// Specifies the FreeAgent API environment to target.
+/// </summary>
+public enum FreeAgentEnvironment
+{
+    /// <summary>
+    /// The FreeAgent production environment (<c>https://api.freeagent.com/v2/</c>).
+    /// </summary>
+    Production,
+
+    /// <summary>
+    /// The FreeAgent sandbox environment (<c>https://api.sandbox.freeagent.com/v2/</c>).
+    /// Use for safe, isolated testing without real data.
+    /// </summary>
+    Sandbox
+}

--- a/src/FreeAgent.Client/FreeAgentEnvironmentEndpoints.cs
+++ b/src/FreeAgent.Client/FreeAgentEnvironmentEndpoints.cs
@@ -1,0 +1,37 @@
+namespace FreeAgent.Client;
+
+/// <summary>
+/// Provides canonical API and OAuth endpoint URLs for each FreeAgent environment.
+/// </summary>
+public static class FreeAgentEnvironmentEndpoints
+{
+    /// <summary>
+    /// Gets the REST API base URL for the selected environment.
+    /// </summary>
+    /// <param name="environment">Target FreeAgent environment.</param>
+    /// <returns>API base URL ending with <c>/v2/</c>.</returns>
+    public static string GetApiBaseUrl(FreeAgentEnvironment environment) =>
+        environment == FreeAgentEnvironment.Sandbox
+            ? "https://api.sandbox.freeagent.com/v2/"
+            : "https://api.freeagent.com/v2/";
+
+    /// <summary>
+    /// Gets the OAuth authorization endpoint for the selected environment.
+    /// </summary>
+    /// <param name="environment">Target FreeAgent environment.</param>
+    /// <returns>OAuth authorization endpoint URL.</returns>
+    public static string GetOAuthAuthorizationEndpoint(FreeAgentEnvironment environment) =>
+        environment == FreeAgentEnvironment.Sandbox
+            ? "https://api.sandbox.freeagent.com/v2/approve_app"
+            : "https://api.freeagent.com/v2/approve_app";
+
+    /// <summary>
+    /// Gets the OAuth token endpoint for the selected environment.
+    /// </summary>
+    /// <param name="environment">Target FreeAgent environment.</param>
+    /// <returns>OAuth token endpoint URL.</returns>
+    public static string GetOAuthTokenEndpoint(FreeAgentEnvironment environment) =>
+        environment == FreeAgentEnvironment.Sandbox
+            ? "https://api.sandbox.freeagent.com/v2/token_endpoint"
+            : "https://api.freeagent.com/v2/token_endpoint";
+}

--- a/src/FreeAgent.Client/Http/FreeAgentHttpClient.cs
+++ b/src/FreeAgent.Client/Http/FreeAgentHttpClient.cs
@@ -18,7 +18,7 @@ public class FreeAgentHttpClient : IDisposable
     private DateTime _nextAllowedRequestTime = DateTime.MinValue;
     private bool _disposed;
 
-    private const string BaseUrl = "https://api.freeagent.com/v2/";
+    private const string DefaultBaseUrl = "https://api.freeagent.com/v2/";
     private const int DefaultRateLimitDelayMs = 1000; // 1 request per second as a safe default
 
     // Cached to avoid allocating a new instance per call (CA1869)
@@ -31,14 +31,15 @@ public class FreeAgentHttpClient : IDisposable
     /// Initializes a new instance with an access token.
     /// </summary>
     /// <param name="accessToken">OAuth access token</param>
-    public FreeAgentHttpClient(string accessToken)
+    /// <param name="environment">Target API environment. Defaults to <see cref="FreeAgentEnvironment.Production"/>.</param>
+    public FreeAgentHttpClient(string accessToken, FreeAgentEnvironment environment = FreeAgentEnvironment.Production)
     {
         if (string.IsNullOrEmpty(accessToken))
         {
             throw new ArgumentNullException(nameof(accessToken));
         }
 
-        _httpClient = new HttpClient { BaseAddress = new Uri(BaseUrl) };
+        _httpClient = new HttpClient { BaseAddress = new Uri(FreeAgentEnvironmentEndpoints.GetApiBaseUrl(environment)) };
         _ownsHttpClient = true;
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "FreeAgent.Client/1.0");
@@ -49,12 +50,13 @@ public class FreeAgentHttpClient : IDisposable
     /// </summary>
     /// <param name="oauthClient">OAuth client for token refresh</param>
     /// <param name="token">Initial OAuth token</param>
-    public FreeAgentHttpClient(FreeAgentOAuthClient oauthClient, OAuthTokenResponse token)
+    /// <param name="environment">Target API environment. Defaults to <see cref="FreeAgentEnvironment.Production"/>.</param>
+    public FreeAgentHttpClient(FreeAgentOAuthClient oauthClient, OAuthTokenResponse token, FreeAgentEnvironment environment = FreeAgentEnvironment.Production)
     {
         _oauthClient = oauthClient ?? throw new ArgumentNullException(nameof(oauthClient));
         _currentToken = token ?? throw new ArgumentNullException(nameof(token));
 
-        _httpClient = new HttpClient { BaseAddress = new Uri(BaseUrl) };
+        _httpClient = new HttpClient { BaseAddress = new Uri(FreeAgentEnvironmentEndpoints.GetApiBaseUrl(environment)) };
         _ownsHttpClient = true;
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {token.AccessToken}");
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "FreeAgent.Client/1.0");
@@ -77,7 +79,7 @@ public class FreeAgentHttpClient : IDisposable
 
         if (_httpClient.BaseAddress == null)
         {
-            _httpClient.BaseAddress = new Uri(BaseUrl);
+            _httpClient.BaseAddress = new Uri(DefaultBaseUrl);
         }
 
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
@@ -172,13 +174,13 @@ public class FreeAgentHttpClient : IDisposable
                 {
                     var oldRefreshToken = _currentToken.RefreshToken;
                     var newToken = await _oauthClient.RefreshTokenAsync(_currentToken.RefreshToken, cancellationToken);
-                    
+
                     // Preserve the refresh token if the provider doesn't return a new one
                     if (string.IsNullOrEmpty(newToken.RefreshToken))
                     {
                         newToken.RefreshToken = oldRefreshToken;
                     }
-                    
+
                     _currentToken = newToken;
 
                     _httpClient.DefaultRequestHeaders.Remove("Authorization");
@@ -203,7 +205,7 @@ public class FreeAgentHttpClient : IDisposable
                 var delay = _nextAllowedRequestTime - now;
                 await Task.Delay(delay, cancellationToken);
             }
-            
+
             // Reserve the next slot before releasing the semaphore
             // Take the max of current time and existing next allowed time to handle concurrent requests
             var currentNextTime = _nextAllowedRequestTime > now ? _nextAllowedRequestTime : now;
@@ -253,7 +255,7 @@ public class FreeAgentHttpClient : IDisposable
                 {
                     retryTime = DateTime.UtcNow.AddSeconds(60);
                 }
-                
+
                 // Only update if this retry time is later than what we already have
                 if (retryTime > _nextAllowedRequestTime)
                 {
@@ -263,7 +265,7 @@ public class FreeAgentHttpClient : IDisposable
                 var errorContent = await response.Content.ReadAsStringAsync(CancellationToken.None);
                 throw new FreeAgentRateLimitException($"Rate limit exceeded. Retry after {_nextAllowedRequestTime}. Response: {errorContent}");
             }
-            
+
             // Note: We don't apply the default delay here anymore since it's now handled in ApplyRateLimitAsync
         }
         finally

--- a/src/FreeAgent.Client/Http/FreeAgentHttpClient.cs
+++ b/src/FreeAgent.Client/Http/FreeAgentHttpClient.cs
@@ -18,7 +18,6 @@ public class FreeAgentHttpClient : IDisposable
     private DateTime _nextAllowedRequestTime = DateTime.MinValue;
     private bool _disposed;
 
-    private const string DefaultBaseUrl = "https://api.freeagent.com/v2/";
     private const int DefaultRateLimitDelayMs = 1000; // 1 request per second as a safe default
 
     // Cached to avoid allocating a new instance per call (CA1869)
@@ -79,7 +78,7 @@ public class FreeAgentHttpClient : IDisposable
 
         if (_httpClient.BaseAddress == null)
         {
-            _httpClient.BaseAddress = new Uri(DefaultBaseUrl);
+            _httpClient.BaseAddress = new Uri(FreeAgentEnvironmentEndpoints.GetApiBaseUrl(FreeAgentEnvironment.Production));
         }
 
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");

--- a/tests/FreeAgent.Client.Tests/Authentication/FreeAgentOAuthClientTests.cs
+++ b/tests/FreeAgent.Client.Tests/Authentication/FreeAgentOAuthClientTests.cs
@@ -8,21 +8,21 @@ public class FreeAgentOAuthClientTests
     [Fact]
     public void Constructor_WithNullClientId_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => 
+        Assert.Throws<ArgumentNullException>(() =>
             new FreeAgentOAuthClient(null!, "secret", "http://localhost"));
     }
 
     [Fact]
     public void Constructor_WithNullClientSecret_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => 
+        Assert.Throws<ArgumentNullException>(() =>
             new FreeAgentOAuthClient("clientId", null!, "http://localhost"));
     }
 
     [Fact]
     public void Constructor_WithNullRedirectUri_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => 
+        Assert.Throws<ArgumentNullException>(() =>
             new FreeAgentOAuthClient("clientId", "secret", null!));
     }
 
@@ -30,9 +30,9 @@ public class FreeAgentOAuthClientTests
     public void GetAuthorizationUrl_ReturnsCorrectUrl()
     {
         var client = new FreeAgentOAuthClient("test-client-id", "test-secret", "http://localhost/callback");
-        
+
         var url = client.GetAuthorizationUrl();
-        
+
         Assert.Contains("https://api.freeagent.com/v2/approve_app", url);
         Assert.Contains("response_type=code", url);
         Assert.Contains("client_id=test-client-id", url);
@@ -43,9 +43,9 @@ public class FreeAgentOAuthClientTests
     public void GetAuthorizationUrl_WithState_IncludesStateParameter()
     {
         var client = new FreeAgentOAuthClient("test-client-id", "test-secret", "http://localhost/callback");
-        
+
         var url = client.GetAuthorizationUrl("test-state-123");
-        
+
         Assert.Contains("state=test-state-123", url);
     }
 
@@ -53,8 +53,8 @@ public class FreeAgentOAuthClientTests
     public async Task ExchangeCodeForTokenAsync_WithNullCode_ThrowsArgumentNullException()
     {
         var client = new FreeAgentOAuthClient("test-client-id", "test-secret", "http://localhost/callback");
-        
-        await Assert.ThrowsAsync<ArgumentNullException>(() => 
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
             client.ExchangeCodeForTokenAsync(null!));
     }
 
@@ -62,8 +62,39 @@ public class FreeAgentOAuthClientTests
     public async Task RefreshTokenAsync_WithNullRefreshToken_ThrowsArgumentNullException()
     {
         var client = new FreeAgentOAuthClient("test-client-id", "test-secret", "http://localhost/callback");
-        
-        await Assert.ThrowsAsync<ArgumentNullException>(() => 
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
             client.RefreshTokenAsync(null!));
+    }
+
+    [Fact]
+    public void GetAuthorizationUrl_WithProductionEnvironment_UsesProductionEndpoint()
+    {
+        var client = new FreeAgentOAuthClient("test-client-id", "test-secret", "http://localhost/callback", FreeAgentEnvironment.Production);
+
+        var url = client.GetAuthorizationUrl();
+
+        Assert.Contains("https://api.freeagent.com/v2/approve_app", url);
+    }
+
+    [Fact]
+    public void GetAuthorizationUrl_WithSandboxEnvironment_UsesSandboxEndpoint()
+    {
+        var client = new FreeAgentOAuthClient("test-client-id", "test-secret", "http://localhost/callback", FreeAgentEnvironment.Sandbox);
+
+        var url = client.GetAuthorizationUrl();
+
+        Assert.Contains("https://api.sandbox.freeagent.com/v2/approve_app", url);
+        Assert.DoesNotContain("https://api.freeagent.com/v2/approve_app", url);
+    }
+
+    [Fact]
+    public void GetAuthorizationUrl_DefaultEnvironment_UsesProductionEndpoint()
+    {
+        var client = new FreeAgentOAuthClient("test-client-id", "test-secret", "http://localhost/callback");
+
+        var url = client.GetAuthorizationUrl();
+
+        Assert.Contains("https://api.freeagent.com/v2/approve_app", url);
     }
 }

--- a/tests/FreeAgent.Client.Tests/FreeAgentEnvironmentEndpointsTests.cs
+++ b/tests/FreeAgent.Client.Tests/FreeAgentEnvironmentEndpointsTests.cs
@@ -1,0 +1,52 @@
+namespace FreeAgent.Client.Tests;
+
+public class FreeAgentEnvironmentEndpointsTests
+{
+    [Fact]
+    public void GetApiBaseUrl_ForProduction_ReturnsProductionBaseUrl()
+    {
+        var value = FreeAgentEnvironmentEndpoints.GetApiBaseUrl(FreeAgentEnvironment.Production);
+
+        Assert.Equal("https://api.freeagent.com/v2/", value);
+    }
+
+    [Fact]
+    public void GetApiBaseUrl_ForSandbox_ReturnsSandboxBaseUrl()
+    {
+        var value = FreeAgentEnvironmentEndpoints.GetApiBaseUrl(FreeAgentEnvironment.Sandbox);
+
+        Assert.Equal("https://api.sandbox.freeagent.com/v2/", value);
+    }
+
+    [Fact]
+    public void GetOAuthAuthorizationEndpoint_ForProduction_ReturnsProductionEndpoint()
+    {
+        var value = FreeAgentEnvironmentEndpoints.GetOAuthAuthorizationEndpoint(FreeAgentEnvironment.Production);
+
+        Assert.Equal("https://api.freeagent.com/v2/approve_app", value);
+    }
+
+    [Fact]
+    public void GetOAuthAuthorizationEndpoint_ForSandbox_ReturnsSandboxEndpoint()
+    {
+        var value = FreeAgentEnvironmentEndpoints.GetOAuthAuthorizationEndpoint(FreeAgentEnvironment.Sandbox);
+
+        Assert.Equal("https://api.sandbox.freeagent.com/v2/approve_app", value);
+    }
+
+    [Fact]
+    public void GetOAuthTokenEndpoint_ForProduction_ReturnsProductionEndpoint()
+    {
+        var value = FreeAgentEnvironmentEndpoints.GetOAuthTokenEndpoint(FreeAgentEnvironment.Production);
+
+        Assert.Equal("https://api.freeagent.com/v2/token_endpoint", value);
+    }
+
+    [Fact]
+    public void GetOAuthTokenEndpoint_ForSandbox_ReturnsSandboxEndpoint()
+    {
+        var value = FreeAgentEnvironmentEndpoints.GetOAuthTokenEndpoint(FreeAgentEnvironment.Sandbox);
+
+        Assert.Equal("https://api.sandbox.freeagent.com/v2/token_endpoint", value);
+    }
+}

--- a/tests/FreeAgent.Client.Tests/FreeAgentEnvironmentTests.cs
+++ b/tests/FreeAgent.Client.Tests/FreeAgentEnvironmentTests.cs
@@ -1,0 +1,44 @@
+using FreeAgent.Client.Authentication;
+
+namespace FreeAgent.Client.Tests;
+
+public class FreeAgentEnvironmentTests
+{
+    [Fact]
+    public void FreeAgentClient_DefaultEnvironment_IsProduction()
+    {
+        var client = new FreeAgentClient("test-token");
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void FreeAgentClient_WithProductionEnvironment_DoesNotThrow()
+    {
+        var client = new FreeAgentClient("test-token", FreeAgentEnvironment.Production);
+
+        Assert.NotNull(client);
+        client.Dispose();
+    }
+
+    [Fact]
+    public void FreeAgentClient_WithSandboxEnvironment_DoesNotThrow()
+    {
+        var client = new FreeAgentClient("test-token", FreeAgentEnvironment.Sandbox);
+
+        Assert.NotNull(client);
+        client.Dispose();
+    }
+
+    [Fact]
+    public void FreeAgentClient_WithOAuthAndSandboxEnvironment_DoesNotThrow()
+    {
+        var oauthClient = new FreeAgentOAuthClient("client-id", "client-secret", "http://localhost", FreeAgentEnvironment.Sandbox);
+        var token = new OAuthTokenResponse { AccessToken = "test-token", TokenType = "Bearer", ExpiresIn = 3600 };
+
+        var client = new FreeAgentClient(oauthClient, token, FreeAgentEnvironment.Sandbox);
+
+        Assert.NotNull(client);
+        client.Dispose();
+    }
+}

--- a/tests/FreeAgent.Client.Tests/FreeAgentEnvironmentTests.cs
+++ b/tests/FreeAgent.Client.Tests/FreeAgentEnvironmentTests.cs
@@ -5,9 +5,9 @@ namespace FreeAgent.Client.Tests;
 public class FreeAgentEnvironmentTests
 {
     [Fact]
-    public void FreeAgentClient_DefaultEnvironment_IsProduction()
+    public void FreeAgentClient_DefaultConstructor_DoesNotThrow()
     {
-        var client = new FreeAgentClient("test-token");
+        using var client = new FreeAgentClient("test-token");
 
         Assert.NotNull(client);
     }


### PR DESCRIPTION
## Summary
- add first-class `FreeAgentEnvironment` support to SDK clients with `Production` default (additive API)
- centralize API/OAuth endpoint authority in `FreeAgentEnvironmentEndpoints`
- wire `FreeAgentClient`, `FreeAgentHttpClient`, and `FreeAgentOAuthClient` to resolve URLs by environment
- update sample app to support environment selection in the Connect flow (locked while connected)
- remove stale sample config-based environment key and align sample docs
- add tests for environment constructors, OAuth URL resolution, and endpoint authority

## Why
Implements issue #20 so developers can safely use sandbox without source edits and keeps endpoint URL ownership in the SDK.

## Validation
- `dotnet build`
- `dotnet test tests/FreeAgent.Client.Tests/FreeAgent.Client.Tests.csproj`
- tests passing: 31/31

Closes #20