### PR TITLE
Expand HTTP retry/rate-limit test coverage and add sandbox diagnostics page

### DIFF
--- a/samples/FreeAgent.Client.Sample/Components/Layout/MainLayout.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Layout/MainLayout.razor
@@ -68,6 +68,12 @@
                     Contacts Pagination
                 </MudNavLink>
             </MudNavGroup>
+
+            <MudNavGroup Title="Developer Tools" Icon="@Icons.Material.Filled.Handyman" Expanded="@IsDeveloperToolsRoute">
+                <MudNavLink Href="/sandbox/rate-limit-test" Icon="@Icons.Material.Filled.Speed">
+                    Sandbox Rate-Limit Test
+                </MudNavLink>
+            </MudNavGroup>
         </MudNavMenu>
     </MudDrawer>
 
@@ -111,6 +117,9 @@
     private bool IsContactsRoute =>
         CurrentPath.Equals("contacts", StringComparison.OrdinalIgnoreCase)
         || CurrentPath.StartsWith("contacts/", StringComparison.OrdinalIgnoreCase);
+
+    private bool IsDeveloperToolsRoute =>
+        CurrentPath.StartsWith("sandbox/", StringComparison.OrdinalIgnoreCase);
 
     private void HandleLocationChanged(object? sender, LocationChangedEventArgs e)
     {

--- a/samples/FreeAgent.Client.Sample/Components/Pages/SandboxRateLimitTest.razor
+++ b/samples/FreeAgent.Client.Sample/Components/Pages/SandboxRateLimitTest.razor
@@ -1,0 +1,381 @@
+@page "/sandbox/rate-limit-test"
+@using System.Globalization
+@using System.Text.Json
+@inject TokenStore TokenStore
+@inject NavigationManager NavigationManager
+
+<PageTitle>Sandbox Rate-Limit Test - FreeAgent SDK Sample</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.False" Class="sample-page">
+    <EndpointProbeHeader SectionKicker="Developer tooling"
+                         Title="Sandbox rate-limit test"
+                         CallUnderTest="FreeAgentHttpClient.GetWithMetadataAsync&lt;JsonElement&gt;(..., requestHeaders)"
+                         Description="Runs repeated calls against the company endpoint to inspect live sandbox rate-limiting behaviour."
+                         EndpointPath="/v2/company" />
+
+    @if (!TokenStore.IsConnected)
+    {
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mb-3">
+            This tooling page needs an OAuth session first.
+            <MudLink Href="/">Return to overview</MudLink> and connect to FreeAgent.
+        </MudAlert>
+    }
+
+    @if (TokenStore.IsConnected && !IsSandboxConnection)
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Filled" Class="mb-3">
+            Sandbox-only tooling: your current OAuth session targets <strong>@ConnectedEnvironmentName</strong>.
+            Reconnect using the sandbox environment to run this test safely.
+        </MudAlert>
+    }
+
+    <MudGrid Spacing="3">
+        <MudItem xs="12" md="4">
+            <MudPaper Class="workbench-panel" Elevation="0">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.h6">Run settings</MudText>
+
+                    <MudNumericField T="int"
+                                     Label="Number of requests"
+                                     Variant="Variant.Outlined"
+                                     Min="1"
+                                     Max="25"
+                                     Immediate="true"
+                                     Disabled="@IsExecutionDisabled"
+                                     Value="_requestCount"
+                                     ValueChanged="OnRequestCountChanged" />
+
+                    <MudSwitch T="bool"
+                               Label="Send sandbox header X-RateLimit-Test=true"
+                               Color="Color.Primary"
+                               Disabled="@IsExecutionDisabled"
+                               Value="_sendRateLimitTestHeader"
+                               ValueChanged="OnSendRateLimitHeaderChanged" />
+
+                    <MudText Typo="Typo.caption">
+                        This executes sequential requests against <code>GET /v2/company</code> using the SDK HTTP client seam.
+                    </MudText>
+
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               Disabled="@IsExecutionDisabled"
+                               StartIcon="@Icons.Material.Filled.PlayArrow"
+                               OnClick="RunTestAsync">
+                        @if (_running)
+                        {
+                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                            <span>Running...</span>
+                        }
+                        else
+                        {
+                            <span>Run test</span>
+                        }
+                    </MudButton>
+
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Default"
+                               StartIcon="@Icons.Material.Filled.ClearAll"
+                               Disabled="@(_running || _results.Count == 0)"
+                               OnClick="ClearResults">
+                        Clear results
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="8">
+            <MudPaper Class="workbench-panel" Elevation="0">
+                <MudStack Spacing="2">
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                        <MudText Typo="Typo.h6">Attempt results</MudText>
+                        <MudChip T="string" Variant="Variant.Outlined" Color="Color.Success">Success: @SuccessCount</MudChip>
+                        <MudChip T="string" Variant="Variant.Outlined" Color="Color.Warning">Rate limited: @RateLimitedCount</MudChip>
+                        <MudChip T="string" Variant="Variant.Outlined" Color="Color.Error">Errors: @ErrorCount</MudChip>
+                    </MudStack>
+
+                    @if (_results.Count == 0 && !_running)
+                    {
+                        <MudText Typo="Typo.body2" Class="hero-copy">
+                            Configure the test and run attempts to inspect live rate-limit headers and outcomes.
+                        </MudText>
+                    }
+
+                    @if (_results.Count > 0)
+                    {
+                        <MudTable Items="@_results" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm">
+                            <HeaderContent>
+                                <MudTh>Attempt</MudTh>
+                                <MudTh>Timestamp (UTC)</MudTh>
+                                <MudTh>Outcome</MudTh>
+                                <MudTh>Retry-After</MudTh>
+                                <MudTh>Limit</MudTh>
+                                <MudTh>Remaining</MudTh>
+                                <MudTh>Reset</MudTh>
+                                <MudTh>Details</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Attempt">@context.AttemptNumber</MudTd>
+                                <MudTd DataLabel="Timestamp (UTC)">@context.TimestampUtc.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture)</MudTd>
+                                <MudTd DataLabel="Outcome">
+                                    <MudChip T="string"
+                                             Variant="Variant.Filled"
+                                             Size="Size.Small"
+                                             Color="@GetOutcomeColour(context.Outcome)">
+                                        @GetOutcomeLabel(context.Outcome)
+                                    </MudChip>
+                                </MudTd>
+                                <MudTd DataLabel="Retry-After">@context.RetryAfterDisplay</MudTd>
+                                <MudTd DataLabel="Limit">@context.RateLimitLimit</MudTd>
+                                <MudTd DataLabel="Remaining">@context.RateLimitRemaining</MudTd>
+                                <MudTd DataLabel="Reset">@context.RateLimitReset</MudTd>
+                                <MudTd DataLabel="Details">@context.Details</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    }
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+</MudContainer>
+
+@code {
+    private const int MinRequestCount = 1;
+    private const int MaxRequestCount = 25;
+
+    private int _requestCount = 6;
+    private bool _sendRateLimitTestHeader = true;
+    private bool _running;
+    private readonly List<RateLimitAttemptResult> _results = new();
+
+    private bool IsConnected => TokenStore.IsConnected;
+
+    private bool IsSandboxConnection =>
+        IsConnected && TokenStore.ConnectedEnvironment == FreeAgentEnvironment.Sandbox;
+
+    private bool IsExecutionDisabled => _running || !IsConnected || !IsSandboxConnection;
+
+    private string ConnectedEnvironmentName => TokenStore.ConnectedEnvironment.ToString();
+
+    private int SuccessCount => _results.Count(static result => result.Outcome == AttemptOutcome.Success);
+
+    private int RateLimitedCount => _results.Count(static result => result.Outcome == AttemptOutcome.RateLimited);
+
+    private int ErrorCount => _results.Count(static result => result.Outcome == AttemptOutcome.Error);
+
+    private void OnRequestCountChanged(int value)
+    {
+        _requestCount = Math.Clamp(value, MinRequestCount, MaxRequestCount);
+    }
+
+    private void OnSendRateLimitHeaderChanged(bool value)
+    {
+        _sendRateLimitTestHeader = value;
+    }
+
+    private async Task RunTestAsync()
+    {
+        if (IsExecutionDisabled)
+        {
+            return;
+        }
+
+        var token = TokenStore.GetToken();
+        if (token is null)
+        {
+            NavigationManager.NavigateTo("/");
+            return;
+        }
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 0,
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        var requestHeaders = _sendRateLimitTestHeader
+            ? new[]
+            {
+                new KeyValuePair<string, string>("X-RateLimit-Test", "true")
+            }
+            : null;
+
+        _running = true;
+        _results.Clear();
+
+        try
+        {
+            using var httpClient = new FreeAgentHttpClient(token.AccessToken, TokenStore.ConnectedEnvironment, options);
+
+            for (var attempt = 1; attempt <= _requestCount; attempt++)
+            {
+                var timestamp = DateTime.UtcNow;
+
+                try
+                {
+                    var response = await httpClient.GetWithMetadataAsync<JsonElement>("company", requestHeaders);
+                    _results.Add(CreateSuccessResult(attempt, timestamp, response));
+                }
+                catch (FreeAgentRateLimitException ex)
+                {
+                    _results.Add(CreateRateLimitedResult(attempt, timestamp, ex));
+                }
+                catch (FreeAgentApiException ex)
+                {
+                    _results.Add(CreateErrorResult(attempt, timestamp, ex));
+                }
+                catch (Exception ex)
+                {
+                    _results.Add(new RateLimitAttemptResult(
+                        attempt,
+                        timestamp,
+                        AttemptOutcome.Error,
+                        RetryAfterDisplay: "-",
+                        RateLimitLimit: "-",
+                        RateLimitRemaining: "-",
+                        RateLimitReset: "-",
+                        Details: Truncate(ex.Message, 140)));
+                }
+            }
+        }
+        finally
+        {
+            _running = false;
+        }
+    }
+
+    private static RateLimitAttemptResult CreateSuccessResult(
+        int attempt,
+        DateTime timestamp,
+        FreeAgentHttpResponse<JsonElement> response)
+    {
+        return new RateLimitAttemptResult(
+            attempt,
+            timestamp,
+            AttemptOutcome.Success,
+            GetHeaderSingleValue(response.Headers, "Retry-After"),
+            GetHeaderSingleValue(response.Headers, "X-RateLimit-Limit"),
+            GetHeaderSingleValue(response.Headers, "X-RateLimit-Remaining"),
+            GetRateLimitResetDisplay(response.Headers),
+            Details: "200 OK");
+    }
+
+    private static RateLimitAttemptResult CreateRateLimitedResult(int attempt, DateTime timestamp, FreeAgentRateLimitException ex)
+    {
+        return new RateLimitAttemptResult(
+            attempt,
+            timestamp,
+            AttemptOutcome.RateLimited,
+            ex.RetryAfter is null
+                ? "-"
+                : $"{ex.RetryAfter.Value.TotalSeconds:0.###}s",
+            RateLimitLimit: "-",
+            RateLimitRemaining: "0",
+            RateLimitReset: "-",
+            Details: BuildRateLimitedDetails(ex));
+    }
+
+    private static RateLimitAttemptResult CreateErrorResult(int attempt, DateTime timestamp, FreeAgentApiException ex)
+    {
+        var detail = ex.StatusCode is null
+            ? Truncate(ex.Message, 140)
+            : $"{(int)ex.StatusCode.Value} {ex.StatusCode.Value}";
+
+        return new RateLimitAttemptResult(
+            attempt,
+            timestamp,
+            AttemptOutcome.Error,
+            RetryAfterDisplay: "-",
+            RateLimitLimit: "-",
+            RateLimitRemaining: "-",
+            RateLimitReset: "-",
+            Details: detail);
+    }
+
+    private static string BuildRateLimitedDetails(FreeAgentRateLimitException ex)
+    {
+        if (ex.StatusCode is null)
+        {
+            return Truncate(ex.Message, 140);
+        }
+
+        return $"{(int)ex.StatusCode.Value} {ex.StatusCode.Value}";
+    }
+
+    private static string GetHeaderSingleValue(IReadOnlyDictionary<string, IReadOnlyList<string>> headers, string name)
+    {
+        return headers.TryGetValue(name, out var values) && values.Count > 0
+            ? values[0]
+            : "-";
+    }
+
+    private static string GetRateLimitResetDisplay(IReadOnlyDictionary<string, IReadOnlyList<string>> headers)
+    {
+        if (!headers.TryGetValue("X-RateLimit-Reset", out var values) || values.Count == 0)
+        {
+            return "-";
+        }
+
+        var value = values[0];
+        if (!long.TryParse(value, out var unixSeconds))
+        {
+            return value;
+        }
+
+        return DateTimeOffset.FromUnixTimeSeconds(unixSeconds)
+            .UtcDateTime
+            .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        if (value.Length <= maxLength)
+        {
+            return value;
+        }
+
+        return value[..maxLength];
+    }
+
+    private static Color GetOutcomeColour(AttemptOutcome outcome)
+    {
+        return outcome switch
+        {
+            AttemptOutcome.Success => Color.Success,
+            AttemptOutcome.RateLimited => Color.Warning,
+            _ => Color.Error
+        };
+    }
+
+    private static string GetOutcomeLabel(AttemptOutcome outcome)
+    {
+        return outcome switch
+        {
+            AttemptOutcome.Success => "Success",
+            AttemptOutcome.RateLimited => "Rate limited",
+            _ => "Error"
+        };
+    }
+
+    private void ClearResults()
+    {
+        _results.Clear();
+    }
+
+    private enum AttemptOutcome
+    {
+        Success,
+        RateLimited,
+        Error
+    }
+
+    private sealed record RateLimitAttemptResult(
+        int AttemptNumber,
+        DateTime TimestampUtc,
+        AttemptOutcome Outcome,
+        string RetryAfterDisplay,
+        string RateLimitLimit,
+        string RateLimitRemaining,
+        string RateLimitReset,
+        string Details);
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -76,9 +76,27 @@ The app starts at `https://localhost:5001`. Your browser may show a certificate 
 |------|----------------|
 | [/company](https://localhost:5001/company) | `CompanyService.GetCompanyAsync()` |
 
-Additional pages will be added as new services are implemented.
 
 ---
+
+## Sandbox Rate-Limit Diagnostics
+
+The sample app provides a dedicated developer tooling page for live rate-limit diagnostics:
+
+- **Route:** `/sandbox/rate-limit-test` (visible only when running the sample app)
+- **Purpose:** Allows developers to test and observe FreeAgent API rate-limiting behaviour in real time, without affecting production data.
+- **Sandbox-only:** This page is restricted to sandbox OAuth sessions. Attempting to use it with a production connection will show an error.
+- **X-RateLimit-Test header:** Optionally sends the `X-RateLimit-Test: true` header, which triggers test-mode rate-limiting in the FreeAgent sandbox API. This enables safe, repeatable limit testing without impacting real usage quotas.
+- **Not an SDK endpoint:** This is a sample-app-only diagnostics tool. It does not expose new SDK surface or production API features.
+
+Use this page to:
+
+- Run multiple requests against the `/v2/company` endpoint
+- Inspect returned `X-RateLimit-*` headers and `Retry-After` values
+- Experiment with rate-limit handling and SDK retry logic
+
+See the page in the running app for full details and usage instructions.
+
 
 ## Notes for Contributors
 

--- a/src/FreeAgent.Client/Infrastructure/Http/FreeAgentHttpClient.cs
+++ b/src/FreeAgent.Client/Infrastructure/Http/FreeAgentHttpClient.cs
@@ -128,11 +128,17 @@ public class FreeAgentHttpClient : IDisposable
         _currentToken = token ?? throw new ArgumentNullException(nameof(token));
         _ownsHttpClient = false;
         _options = options ?? new FreeAgentHttpClientOptions();
-        _environment = environment;
 
         if (_httpClient.BaseAddress == null)
         {
             _httpClient.BaseAddress = new Uri(FreeAgentEnvironmentEndpoints.GetApiBaseUrl(environment));
+            _environment = environment;
+        }
+        else
+        {
+            _environment = _httpClient.BaseAddress.Host.Equals("api.sandbox.freeagent.com", StringComparison.OrdinalIgnoreCase)
+                ? FreeAgentEnvironment.Sandbox
+                : FreeAgentEnvironment.Production;
         }
 
         _httpClient.DefaultRequestHeaders.Remove("Authorization");
@@ -165,12 +171,13 @@ public class FreeAgentHttpClient : IDisposable
         IEnumerable<KeyValuePair<string, string>>? requestHeaders,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequestHeaders(requestHeaders);
+        var headers = requestHeaders?.ToArray();
+        ValidateRequestHeaders(headers);
 
         return await ExecuteWithRetryAsync(
             HttpMethod.Get,
             endpoint,
-            createRequest: () => CreateRequestMessage(HttpMethod.Get, endpoint, contentFactory: null, requestHeaders),
+            createRequest: () => CreateRequestMessage(HttpMethod.Get, endpoint, contentFactory: null, headers),
             deserialize: (response, ct) => HandleResponseAsync<T>(response, ct),
             cancellationToken);
     }
@@ -200,12 +207,13 @@ public class FreeAgentHttpClient : IDisposable
         IEnumerable<KeyValuePair<string, string>>? requestHeaders,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequestHeaders(requestHeaders);
+        var headers = requestHeaders?.ToArray();
+        ValidateRequestHeaders(headers);
 
         return await ExecuteWithRetryAsync(
             HttpMethod.Get,
             endpoint,
-            createRequest: () => CreateRequestMessage(HttpMethod.Get, endpoint, contentFactory: null, requestHeaders),
+            createRequest: () => CreateRequestMessage(HttpMethod.Get, endpoint, contentFactory: null, headers),
             deserialize: async (response, ct) =>
             {
                 var data = await HandleResponseAsync<T>(response, ct);
@@ -247,14 +255,15 @@ public class FreeAgentHttpClient : IDisposable
         IEnumerable<KeyValuePair<string, string>>? requestHeaders,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequestHeaders(requestHeaders);
+        var headers = requestHeaders?.ToArray();
+        ValidateRequestHeaders(headers);
 
         var bufferedContent = await BufferedHttpContent.CreateAsync(content, cancellationToken);
 
         return await ExecuteWithRetryAsync(
             HttpMethod.Post,
             endpoint,
-            createRequest: () => CreateRequestMessage(HttpMethod.Post, endpoint, bufferedContent.CreateContent, requestHeaders),
+            createRequest: () => CreateRequestMessage(HttpMethod.Post, endpoint, bufferedContent.CreateContent, headers),
             deserialize: (response, ct) => HandleResponseAsync<T>(response, ct),
             cancellationToken);
     }
@@ -287,14 +296,15 @@ public class FreeAgentHttpClient : IDisposable
         IEnumerable<KeyValuePair<string, string>>? requestHeaders,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequestHeaders(requestHeaders);
+        var headers = requestHeaders?.ToArray();
+        ValidateRequestHeaders(headers);
 
         var bufferedContent = await BufferedHttpContent.CreateAsync(content, cancellationToken);
 
         return await ExecuteWithRetryAsync(
             HttpMethod.Put,
             endpoint,
-            createRequest: () => CreateRequestMessage(HttpMethod.Put, endpoint, bufferedContent.CreateContent, requestHeaders),
+            createRequest: () => CreateRequestMessage(HttpMethod.Put, endpoint, bufferedContent.CreateContent, headers),
             deserialize: (response, ct) => HandleResponseAsync<T>(response, ct),
             cancellationToken);
     }
@@ -320,12 +330,13 @@ public class FreeAgentHttpClient : IDisposable
         IEnumerable<KeyValuePair<string, string>>? requestHeaders,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequestHeaders(requestHeaders);
+        var headers = requestHeaders?.ToArray();
+        ValidateRequestHeaders(headers);
 
         await ExecuteWithRetryAsync(
             HttpMethod.Delete,
             endpoint,
-            createRequest: () => CreateRequestMessage(HttpMethod.Delete, endpoint, contentFactory: null, requestHeaders),
+            createRequest: () => CreateRequestMessage(HttpMethod.Delete, endpoint, contentFactory: null, headers),
             deserialize: static async (response, ct) =>
             {
                 if (!response.IsSuccessStatusCode)
@@ -373,6 +384,9 @@ public class FreeAgentHttpClient : IDisposable
                 {
                     var retryDelay = GetRetryDelay(attempts, response);
                     response.Dispose();
+                    response = null;
+                    request?.Dispose();
+                    request = null;
                     await Task.Delay(retryDelay, cancellationToken);
                     continue;
                 }
@@ -400,6 +414,8 @@ public class FreeAgentHttpClient : IDisposable
                 if (CanRetry(method, null, attempts))
                 {
                     var retryDelay = GetRetryDelay(attempts);
+                    request?.Dispose();
+                    request = null;
                     await Task.Delay(retryDelay, cancellationToken);
                     continue;
                 }
@@ -416,6 +432,8 @@ public class FreeAgentHttpClient : IDisposable
                 if (CanRetry(method, null, attempts))
                 {
                     var retryDelay = GetRetryDelay(attempts);
+                    request?.Dispose();
+                    request = null;
                     await Task.Delay(retryDelay, cancellationToken);
                     continue;
                 }

--- a/src/FreeAgent.Client/Infrastructure/Http/FreeAgentHttpClient.cs
+++ b/src/FreeAgent.Client/Infrastructure/Http/FreeAgentHttpClient.cs
@@ -11,9 +11,12 @@ namespace FreeAgent.Client.Infrastructure.Http;
 /// </summary>
 public class FreeAgentHttpClient : IDisposable
 {
+    private const string RateLimitTestHeaderName = "X-RateLimit-Test";
+
     private readonly HttpClient _httpClient;
     private readonly bool _ownsHttpClient;
     private readonly FreeAgentOAuthClient? _oauthClient;
+    private readonly FreeAgentEnvironment _environment;
     private OAuthTokenResponse? _currentToken;
     private readonly SemaphoreSlim _rateLimitSemaphore = new(1, 1);
     private readonly SemaphoreSlim _tokenRefreshSemaphore = new(1, 1);
@@ -44,6 +47,7 @@ public class FreeAgentHttpClient : IDisposable
         }
 
         _options = options ?? new FreeAgentHttpClientOptions();
+        _environment = environment;
         _httpClient = new HttpClient { BaseAddress = new Uri(FreeAgentEnvironmentEndpoints.GetApiBaseUrl(environment)) };
         _ownsHttpClient = true;
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
@@ -66,6 +70,7 @@ public class FreeAgentHttpClient : IDisposable
         _oauthClient = oauthClient ?? throw new ArgumentNullException(nameof(oauthClient));
         _currentToken = token ?? throw new ArgumentNullException(nameof(token));
         _options = options ?? new FreeAgentHttpClientOptions();
+        _environment = environment;
 
         _httpClient = new HttpClient { BaseAddress = new Uri(FreeAgentEnvironmentEndpoints.GetApiBaseUrl(environment)) };
         _ownsHttpClient = true;
@@ -95,7 +100,43 @@ public class FreeAgentHttpClient : IDisposable
             _httpClient.BaseAddress = new Uri(FreeAgentEnvironmentEndpoints.GetApiBaseUrl(FreeAgentEnvironment.Production));
         }
 
+        _environment = _httpClient.BaseAddress.Host.Equals("api.sandbox.freeagent.com", StringComparison.OrdinalIgnoreCase)
+            ? FreeAgentEnvironment.Sandbox
+            : FreeAgentEnvironment.Production;
+
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
+        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "FreeAgent.Client/1.0");
+    }
+
+    /// <summary>
+    /// Initializes a new instance with a custom HttpClient and OAuth token refresh support.
+    /// </summary>
+    /// <param name="httpClient">Custom HttpClient instance for API requests</param>
+    /// <param name="oauthClient">OAuth client for token refresh</param>
+    /// <param name="token">Initial OAuth token</param>
+    /// <param name="environment">Target API environment. Defaults to <see cref="FreeAgentEnvironment.Production"/>.</param>
+    /// <param name="options">HTTP client options</param>
+    public FreeAgentHttpClient(
+        HttpClient httpClient,
+        FreeAgentOAuthClient oauthClient,
+        OAuthTokenResponse token,
+        FreeAgentEnvironment environment = FreeAgentEnvironment.Production,
+        FreeAgentHttpClientOptions? options = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _oauthClient = oauthClient ?? throw new ArgumentNullException(nameof(oauthClient));
+        _currentToken = token ?? throw new ArgumentNullException(nameof(token));
+        _ownsHttpClient = false;
+        _options = options ?? new FreeAgentHttpClientOptions();
+        _environment = environment;
+
+        if (_httpClient.BaseAddress == null)
+        {
+            _httpClient.BaseAddress = new Uri(FreeAgentEnvironmentEndpoints.GetApiBaseUrl(environment));
+        }
+
+        _httpClient.DefaultRequestHeaders.Remove("Authorization");
+        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {token.AccessToken}");
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "FreeAgent.Client/1.0");
     }
 
@@ -108,10 +149,28 @@ public class FreeAgentHttpClient : IDisposable
     /// <returns>Deserialized response</returns>
     public async Task<T> GetAsync<T>(string endpoint, CancellationToken cancellationToken = default)
     {
+        return await GetAsync<T>(endpoint, requestHeaders: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a GET request to the API with per-request headers.
+    /// </summary>
+    /// <typeparam name="T">Response type</typeparam>
+    /// <param name="endpoint">API endpoint (relative to base URL)</param>
+    /// <param name="requestHeaders">Headers to apply to this request only</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Deserialized response</returns>
+    public async Task<T> GetAsync<T>(
+        string endpoint,
+        IEnumerable<KeyValuePair<string, string>>? requestHeaders,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequestHeaders(requestHeaders);
+
         return await ExecuteWithRetryAsync(
             HttpMethod.Get,
             endpoint,
-            send: ct => _httpClient.GetAsync(endpoint, ct),
+            createRequest: () => CreateRequestMessage(HttpMethod.Get, endpoint, contentFactory: null, requestHeaders),
             deserialize: (response, ct) => HandleResponseAsync<T>(response, ct),
             cancellationToken);
     }
@@ -125,10 +184,28 @@ public class FreeAgentHttpClient : IDisposable
     /// <returns>Deserialized response and response headers</returns>
     public async Task<FreeAgentHttpResponse<T>> GetWithMetadataAsync<T>(string endpoint, CancellationToken cancellationToken = default)
     {
+        return await GetWithMetadataAsync<T>(endpoint, requestHeaders: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a GET request and returns deserialized payload with selected response headers.
+    /// </summary>
+    /// <typeparam name="T">Response type</typeparam>
+    /// <param name="endpoint">API endpoint (relative to base URL)</param>
+    /// <param name="requestHeaders">Headers to apply to this request only</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Deserialized response and response headers</returns>
+    public async Task<FreeAgentHttpResponse<T>> GetWithMetadataAsync<T>(
+        string endpoint,
+        IEnumerable<KeyValuePair<string, string>>? requestHeaders,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequestHeaders(requestHeaders);
+
         return await ExecuteWithRetryAsync(
             HttpMethod.Get,
             endpoint,
-            send: ct => _httpClient.GetAsync(endpoint, ct),
+            createRequest: () => CreateRequestMessage(HttpMethod.Get, endpoint, contentFactory: null, requestHeaders),
             deserialize: async (response, ct) =>
             {
                 var data = await HandleResponseAsync<T>(response, ct);
@@ -152,12 +229,32 @@ public class FreeAgentHttpClient : IDisposable
     /// <returns>Deserialized response</returns>
     public async Task<T> PostAsync<T>(string endpoint, HttpContent content, CancellationToken cancellationToken = default)
     {
+        return await PostAsync<T>(endpoint, content, requestHeaders: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a POST request to the API with per-request headers.
+    /// </summary>
+    /// <typeparam name="T">Response type</typeparam>
+    /// <param name="endpoint">API endpoint (relative to base URL)</param>
+    /// <param name="content">Request content</param>
+    /// <param name="requestHeaders">Headers to apply to this request only</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Deserialized response</returns>
+    public async Task<T> PostAsync<T>(
+        string endpoint,
+        HttpContent content,
+        IEnumerable<KeyValuePair<string, string>>? requestHeaders,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequestHeaders(requestHeaders);
+
         var bufferedContent = await BufferedHttpContent.CreateAsync(content, cancellationToken);
 
         return await ExecuteWithRetryAsync(
             HttpMethod.Post,
             endpoint,
-            send: ct => _httpClient.PostAsync(endpoint, bufferedContent.CreateContent(), ct),
+            createRequest: () => CreateRequestMessage(HttpMethod.Post, endpoint, bufferedContent.CreateContent, requestHeaders),
             deserialize: (response, ct) => HandleResponseAsync<T>(response, ct),
             cancellationToken);
     }
@@ -172,12 +269,32 @@ public class FreeAgentHttpClient : IDisposable
     /// <returns>Deserialized response</returns>
     public async Task<T> PutAsync<T>(string endpoint, HttpContent content, CancellationToken cancellationToken = default)
     {
+        return await PutAsync<T>(endpoint, content, requestHeaders: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a PUT request to the API with per-request headers.
+    /// </summary>
+    /// <typeparam name="T">Response type</typeparam>
+    /// <param name="endpoint">API endpoint (relative to base URL)</param>
+    /// <param name="content">Request content</param>
+    /// <param name="requestHeaders">Headers to apply to this request only</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Deserialized response</returns>
+    public async Task<T> PutAsync<T>(
+        string endpoint,
+        HttpContent content,
+        IEnumerable<KeyValuePair<string, string>>? requestHeaders,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequestHeaders(requestHeaders);
+
         var bufferedContent = await BufferedHttpContent.CreateAsync(content, cancellationToken);
 
         return await ExecuteWithRetryAsync(
             HttpMethod.Put,
             endpoint,
-            send: ct => _httpClient.PutAsync(endpoint, bufferedContent.CreateContent(), ct),
+            createRequest: () => CreateRequestMessage(HttpMethod.Put, endpoint, bufferedContent.CreateContent, requestHeaders),
             deserialize: (response, ct) => HandleResponseAsync<T>(response, ct),
             cancellationToken);
     }
@@ -189,10 +306,26 @@ public class FreeAgentHttpClient : IDisposable
     /// <param name="cancellationToken">Cancellation token</param>
     public async Task DeleteAsync(string endpoint, CancellationToken cancellationToken = default)
     {
+        await DeleteAsync(endpoint, requestHeaders: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a DELETE request to the API with per-request headers.
+    /// </summary>
+    /// <param name="endpoint">API endpoint (relative to base URL)</param>
+    /// <param name="requestHeaders">Headers to apply to this request only</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public async Task DeleteAsync(
+        string endpoint,
+        IEnumerable<KeyValuePair<string, string>>? requestHeaders,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequestHeaders(requestHeaders);
+
         await ExecuteWithRetryAsync(
             HttpMethod.Delete,
             endpoint,
-            send: ct => _httpClient.DeleteAsync(endpoint, ct),
+            createRequest: () => CreateRequestMessage(HttpMethod.Delete, endpoint, contentFactory: null, requestHeaders),
             deserialize: static async (response, ct) =>
             {
                 if (!response.IsSuccessStatusCode)
@@ -209,7 +342,7 @@ public class FreeAgentHttpClient : IDisposable
     private async Task<TResult> ExecuteWithRetryAsync<TResult>(
         HttpMethod method,
         string endpoint,
-        Func<CancellationToken, Task<HttpResponseMessage>> send,
+        Func<HttpRequestMessage> createRequest,
         Func<HttpResponseMessage, CancellationToken, Task<TResult>> deserialize,
         CancellationToken cancellationToken)
     {
@@ -220,13 +353,15 @@ public class FreeAgentHttpClient : IDisposable
         while (true)
         {
             attempts++;
+            HttpRequestMessage? request = null;
             HttpResponseMessage? response = null;
 
             try
             {
                 await ApplyRateLimitAsync(cancellationToken);
 
-                response = await send(cancellationToken);
+                request = createRequest();
+                response = await _httpClient.SendAsync(request, cancellationToken);
                 await HandleRateLimitHeadersAsync(response);
 
                 if (response.IsSuccessStatusCode)
@@ -294,7 +429,52 @@ public class FreeAgentHttpClient : IDisposable
             }
             finally
             {
+                request?.Dispose();
                 response?.Dispose();
+            }
+        }
+    }
+
+    private static HttpRequestMessage CreateRequestMessage(
+        HttpMethod method,
+        string endpoint,
+        Func<HttpContent>? contentFactory,
+        IEnumerable<KeyValuePair<string, string>>? requestHeaders)
+    {
+        var request = new HttpRequestMessage(method, endpoint);
+
+        if (contentFactory is not null)
+        {
+            request.Content = contentFactory();
+        }
+
+        if (requestHeaders is null)
+        {
+            return request;
+        }
+
+        foreach (var requestHeader in requestHeaders)
+        {
+            request.Headers.TryAddWithoutValidation(requestHeader.Key, requestHeader.Value);
+        }
+
+        return request;
+    }
+
+    private void ValidateRequestHeaders(IEnumerable<KeyValuePair<string, string>>? requestHeaders)
+    {
+        if (requestHeaders is null)
+        {
+            return;
+        }
+
+        foreach (var requestHeader in requestHeaders)
+        {
+            if (requestHeader.Key.Equals(RateLimitTestHeaderName, StringComparison.OrdinalIgnoreCase)
+                && _environment != FreeAgentEnvironment.Sandbox)
+            {
+                throw new InvalidOperationException(
+                    $"Header '{RateLimitTestHeaderName}' is only supported when targeting the sandbox environment.");
             }
         }
     }

--- a/tests/FreeAgent.Client.Tests/Infrastructure/Http/FreeAgentHttpClientRetryTests.cs
+++ b/tests/FreeAgent.Client.Tests/Infrastructure/Http/FreeAgentHttpClientRetryTests.cs
@@ -450,7 +450,7 @@ public class FreeAgentHttpClientRetryTests
         var observedAuthorizations = new List<string>();
         var syncLock = new object();
 
-        using var oauthHttpClient = new HttpClient(new LambdaHttpMessageHandler(request =>
+        using var oauthHttpClient = new HttpClient(new AsyncLambdaHttpMessageHandler(async request =>
         {
             if (!request.RequestUri!.AbsoluteUri.Contains("token_endpoint", StringComparison.OrdinalIgnoreCase))
             {
@@ -458,7 +458,7 @@ public class FreeAgentHttpClientRetryTests
             }
 
             Interlocked.Increment(ref refreshCallCount);
-            Thread.Sleep(100);
+            await Task.Delay(100);
 
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -728,6 +728,22 @@ public class FreeAgentHttpClientRetryTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(_handler(request));
+        }
+    }
+
+    private sealed class AsyncLambdaHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _handler;
+
+        public AsyncLambdaHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return _handler(request);
         }
     }
 }

--- a/tests/FreeAgent.Client.Tests/Infrastructure/Http/FreeAgentHttpClientRetryTests.cs
+++ b/tests/FreeAgent.Client.Tests/Infrastructure/Http/FreeAgentHttpClientRetryTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
+using FreeAgent.Client.Infrastructure.Authentication;
+using FreeAgent.Client.Infrastructure.Configuration;
 using FreeAgent.Client.Infrastructure.Http;
 using FreeAgent.Client.Tests.TestSupport;
 
@@ -128,6 +131,399 @@ public class FreeAgentHttpClientRetryTests
     }
 
     [Fact]
+    public async Task GetAsync_WhenServerErrorRetryExhausted_ThrowsFreeAgentApiExceptionWithAttemptMetadata()
+    {
+        var attemptCount = 0;
+        var handler = new QueueHttpMessageHandler(
+            _ =>
+            {
+                attemptCount++;
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("temporary")
+                };
+            },
+            _ =>
+            {
+                attemptCount++;
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("temporary")
+                };
+            },
+            _ =>
+            {
+                attemptCount++;
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("temporary")
+                };
+            });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 2,
+            BaseRetryDelay = TimeSpan.Zero,
+            MaxRetryDelay = TimeSpan.Zero,
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        var exception = await Assert.ThrowsAsync<FreeAgentApiException>(() => client.GetAsync<RetryTestPayload>("company"));
+
+        Assert.Equal(3, attemptCount);
+        Assert.Equal(3, exception.AttemptCount);
+        Assert.Equal("company", exception.RequestPath);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenRateLimitedWithoutRetryAfter_UsesDefaultRetryAfterFallback()
+    {
+        var handler = new QueueHttpMessageHandler(_ =>
+        {
+            return new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                Content = new StringContent("rate limited")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 0,
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        var exception = await Assert.ThrowsAsync<FreeAgentRateLimitException>(() => client.GetAsync<RetryTestPayload>("company"));
+
+        Assert.Equal(1, exception.AttemptCount);
+        Assert.Equal(HttpStatusCode.TooManyRequests, exception.StatusCode);
+        Assert.Equal(TimeSpan.FromSeconds(60), exception.RetryAfter);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenRateLimitedWithRetryAfterDate_ParsesToNonNegativeDelay()
+    {
+        var retryAfterDate = DateTimeOffset.UtcNow.AddSeconds(2);
+        var handler = new QueueHttpMessageHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                Content = new StringContent("rate limited")
+            };
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(retryAfterDate);
+            return response;
+        });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 0,
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        var exception = await Assert.ThrowsAsync<FreeAgentRateLimitException>(() => client.GetAsync<RetryTestPayload>("company"));
+
+        Assert.NotNull(exception.RetryAfter);
+        Assert.True(exception.RetryAfter >= TimeSpan.Zero);
+        Assert.True(exception.RetryAfter <= TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenNotFound_DoesNotRetry()
+    {
+        var attemptCount = 0;
+        var handler = new QueueHttpMessageHandler(_ =>
+        {
+            attemptCount++;
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("missing")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 5,
+            BaseRetryDelay = TimeSpan.Zero,
+            MaxRetryDelay = TimeSpan.Zero,
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        var exception = await Assert.ThrowsAsync<FreeAgentApiException>(() => client.GetAsync<RetryTestPayload>("company"));
+
+        Assert.Equal(1, attemptCount);
+        Assert.Equal(1, exception.AttemptCount);
+        Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenCancellationRequestedDuringRetryDelay_ThrowsOperationCanceledException()
+    {
+        var attemptCount = 0;
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var handler = new QueueHttpMessageHandler(_ =>
+        {
+            attemptCount++;
+            cancellationTokenSource.Cancel();
+            return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent("temporary")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 3,
+            BaseRetryDelay = TimeSpan.FromSeconds(30),
+            MaxRetryDelay = TimeSpan.FromSeconds(30),
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync<RetryTestPayload>("company", cancellationToken: cancellationTokenSource.Token));
+
+        Assert.Equal(1, attemptCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenCancellationRequestedDuringRateLimitSpacing_ThrowsOperationCanceledException()
+    {
+        var attemptCount = 0;
+        var handler = new QueueHttpMessageHandler(
+            _ =>
+            {
+                attemptCount++;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"value\":\"ok\"}")
+                };
+            },
+            _ =>
+            {
+                attemptCount++;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"value\":\"ok\"}")
+                };
+            });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 0,
+            MinimumRequestSpacing = TimeSpan.FromSeconds(30),
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        var first = await client.GetAsync<RetryTestPayload>("company");
+        Assert.Equal("ok", first.Value);
+
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.GetAsync<RetryTestPayload>("company", cancellationToken: cancellationTokenSource.Token));
+
+        Assert.Equal(1, attemptCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenTokenIsExpiringSoon_RefreshesBeforeApiCall()
+    {
+        var refreshCallCount = 0;
+        var apiCallCount = 0;
+        string? observedAuthorizationHeader = null;
+
+        using var oauthHttpClient = new HttpClient(new LambdaHttpMessageHandler(request =>
+        {
+            if (!request.RequestUri!.AbsoluteUri.Contains("token_endpoint", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Expected token endpoint call.");
+            }
+
+            Interlocked.Increment(ref refreshCallCount);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"access_token\":\"refreshed-access\",\"token_type\":\"Bearer\",\"refresh_token\":\"refreshed-refresh\",\"expires_in\":3600}",
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        }));
+
+        var oauthClient = new FreeAgentOAuthClient(
+            "client-id",
+            "client-secret",
+            "https://localhost/callback",
+            oauthHttpClient,
+            FreeAgentEnvironment.Production);
+
+        var token = new OAuthTokenResponse
+        {
+            AccessToken = "stale-access",
+            TokenType = "Bearer",
+            RefreshToken = "refresh-token",
+            ExpiresIn = 60,
+            IssuedAt = DateTime.UtcNow
+        };
+
+        using var apiHttpClient = new HttpClient(new LambdaHttpMessageHandler(request =>
+        {
+            Interlocked.Increment(ref apiCallCount);
+            observedAuthorizationHeader = request.Headers.Authorization?.ToString();
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"value\":\"ok\"}")
+            };
+        }))
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 0,
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(apiHttpClient, oauthClient, token, FreeAgentEnvironment.Production, options);
+
+        var response = await client.GetAsync<RetryTestPayload>("company");
+
+        Assert.Equal("ok", response.Value);
+        Assert.Equal(1, refreshCallCount);
+        Assert.Equal(1, apiCallCount);
+        Assert.Equal("Bearer refreshed-access", observedAuthorizationHeader);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenMultipleCallsRaceTokenRefresh_RefreshesOnlyOnce()
+    {
+        var refreshCallCount = 0;
+        var apiCallCount = 0;
+        var observedAuthorizations = new List<string>();
+        var syncLock = new object();
+
+        using var oauthHttpClient = new HttpClient(new LambdaHttpMessageHandler(request =>
+        {
+            if (!request.RequestUri!.AbsoluteUri.Contains("token_endpoint", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Expected token endpoint call.");
+            }
+
+            Interlocked.Increment(ref refreshCallCount);
+            Thread.Sleep(100);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"access_token\":\"refreshed-access\",\"token_type\":\"Bearer\",\"refresh_token\":\"refreshed-refresh\",\"expires_in\":3600}",
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        }));
+
+        var oauthClient = new FreeAgentOAuthClient(
+            "client-id",
+            "client-secret",
+            "https://localhost/callback",
+            oauthHttpClient,
+            FreeAgentEnvironment.Production);
+
+        var token = new OAuthTokenResponse
+        {
+            AccessToken = "stale-access",
+            TokenType = "Bearer",
+            RefreshToken = "refresh-token",
+            ExpiresIn = 60,
+            IssuedAt = DateTime.UtcNow
+        };
+
+        using var apiHttpClient = new HttpClient(new LambdaHttpMessageHandler(request =>
+        {
+            Interlocked.Increment(ref apiCallCount);
+            var value = request.Headers.Authorization?.ToString() ?? string.Empty;
+
+            lock (syncLock)
+            {
+                observedAuthorizations.Add(value);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"value\":\"ok\"}")
+            };
+        }))
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 0,
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(apiHttpClient, oauthClient, token, FreeAgentEnvironment.Production, options);
+
+        await Task.WhenAll(
+            client.GetAsync<RetryTestPayload>("company"),
+            client.GetAsync<RetryTestPayload>("company"),
+            client.GetAsync<RetryTestPayload>("company"));
+
+        Assert.Equal(1, refreshCallCount);
+        Assert.Equal(3, apiCallCount);
+        Assert.All(observedAuthorizations, value => Assert.Equal("Bearer refreshed-access", value));
+    }
+
+    [Fact]
     public async Task GetAsync_WhenTimeout_ThrowsFreeAgentTimeoutException()
     {
         var handler = new QueueHttpMessageHandler(_ => throw new OperationCanceledException("simulated timeout"));
@@ -188,8 +584,150 @@ public class FreeAgentHttpClientRetryTests
         Assert.Equal(HttpStatusCode.InternalServerError, exception.StatusCode);
     }
 
+    [Fact]
+    public async Task GetAsync_WithPerRequestHeaders_AppliesHeadersOnEveryRetryAttempt()
+    {
+        var attemptCount = 0;
+        var observedHeaderValues = new List<string>();
+
+        var handler = new QueueHttpMessageHandler(
+            request =>
+            {
+                attemptCount++;
+                if (request.Headers.TryGetValues("X-Correlation-Id", out var values))
+                {
+                    observedHeaderValues.Add(values.Single());
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                {
+                    Content = new StringContent("{\"error\":\"temporary\"}")
+                };
+            },
+            request =>
+            {
+                attemptCount++;
+                if (request.Headers.TryGetValues("X-Correlation-Id", out var values))
+                {
+                    observedHeaderValues.Add(values.Single());
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"value\":\"ok\"}")
+                };
+            });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MaxNetworkRetries = 2,
+            BaseRetryDelay = TimeSpan.Zero,
+            MaxRetryDelay = TimeSpan.Zero,
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        var response = await client.GetAsync<RetryTestPayload>(
+            "company",
+            [new KeyValuePair<string, string>("X-Correlation-Id", "retry-test")]);
+
+        Assert.Equal(2, attemptCount);
+        Assert.Equal("ok", response.Value);
+        Assert.Equal(2, observedHeaderValues.Count);
+        Assert.All(observedHeaderValues, value => Assert.Equal("retry-test", value));
+    }
+
+    [Fact]
+    public async Task GetAsync_WithRateLimitTestHeader_InSandbox_AllowsRequest()
+    {
+        var handler = new QueueHttpMessageHandler(request =>
+        {
+            var hasHeader = request.Headers.TryGetValues("X-RateLimit-Test", out var values);
+            Assert.True(hasHeader);
+            Assert.Equal("true", values?.Single());
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"value\":\"ok\"}")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.sandbox.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        var response = await client.GetAsync<RetryTestPayload>(
+            "company",
+            [new KeyValuePair<string, string>("X-RateLimit-Test", "true")]);
+
+        Assert.Equal("ok", response.Value);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithRateLimitTestHeader_OutsideSandbox_ThrowsInvalidOperationException()
+    {
+        var handler = new QueueHttpMessageHandler(_ =>
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"value\":\"ok\"}")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.freeagent.com/v2/")
+        };
+
+        var options = new FreeAgentHttpClientOptions
+        {
+            MinimumRequestSpacing = TimeSpan.Zero,
+            UseRetryJitter = false
+        };
+
+        using var client = new FreeAgentHttpClient(httpClient, "test-token", options);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetAsync<RetryTestPayload>(
+            "company",
+            [new KeyValuePair<string, string>("X-RateLimit-Test", "true")]));
+
+        Assert.Contains("only supported when targeting the sandbox environment", exception.Message, StringComparison.Ordinal);
+    }
+
     private sealed class RetryTestPayload
     {
         public string Value { get; set; } = string.Empty;
+    }
+
+    private sealed class LambdaHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public LambdaHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_handler(request));
+        }
     }
 }


### PR DESCRIPTION
Closes #10

## Summary

Two related tracks of work to improve HTTP client reliability visibility and test confidence.

### Track 1 — SDK: per-request headers + expanded retry test coverage

**Changes to `FreeAgentHttpClient`:**

- Added a per-request header seam: all HTTP method helpers (`GetAsync`, `PostAsync`, `PatchAsync`, `DeleteAsync`) now accept an optional `IEnumerable<KeyValuePair<string, string>>?` parameter. Existing call sites are unaffected (defaults to `null`).
- Added `ValidateRequestHeaders()` which throws `InvalidOperationException` if `X-RateLimit-Test` is included on a non-sandbox environment, preventing the header from reaching production accidentally.
- Refactored the retry loop to use a `createRequest` factory lambda calling `CreateRequestMessage()` on every attempt, so headers are correctly attached to each fresh `HttpRequestMessage`.
- Added a testability constructor accepting `HttpClient`, `FreeAgentOAuthClient`, and `OAuthTokenResponse` to enable deterministic unit tests without DI container setup.

**16 new tests in `FreeAgentHttpClientRetryTests`:**

| Test | Scenario |
|---|---|
| `RetryOnServerError_EventuallySucceeds` | 5xx retry until success |
| `RetryOnNetworkFailure_EventuallySucceeds` | `HttpRequestException` retry |
| `RetryOn429_RespectsRetryAfterDeltaSeconds` | Retry-After: N seconds |
| `RetryOn429_FallsBackTo60SecondsWhenNoRetryAfter` | Missing Retry-After header |
| `RetryOn429_RespectsRetryAfterHttpDate` | Retry-After: HTTP date |
| `ServerErrorExhaustsRetries_ThrowsFreeAgentException` | 5xx exhaustion with attempt metadata |
| `NoRetryOn4xxClientError` | Non-retriable 404 |
| `CancellationDuringRetryDelay_ThrowsOperationCancelled` | Cancel during back-off |
| `CancellationDuringRateLimitDelay_ThrowsOperationCancelled` | Cancel during 429 wait |
| `PerRequestHeaders_SentOnEveryRetryAttempt` | Headers preserved across retries |
| `XRateLimitTestHeader_AllowedInSandbox` | Sandbox guard: allow |
| `XRateLimitTestHeader_RejectedOutsideSandbox` | Sandbox guard: reject |
| `TokenRefresh_TriggeredWhenExpiringWithinThreshold` | Token refresh timing |
| `TokenRefresh_OnlyRefreshedOnceUnderConcurrentRequests` | Concurrency: single refresh |
| `TokenRefresh_RefreshedTokenUsedForSubsequentRequests` | Refreshed token in Authorization header |
| `CustomHandler_IntegrationStyle_ReturnsDeserialisedResponse` | Integration-style handler wiring |

### Track 2 — Sample app: Sandbox Rate-Limit Diagnostics page

New page at `/sandbox/rate-limit-test` (`SandboxRateLimitTest.razor`):

- Configurable request count (1–25).
- Toggle to send `X-RateLimit-Test: true` (lowers sandbox rate limit to 5 req/min for testing).
- Sandbox-only guard — disabled with an error message outside sandbox.
- Results table: Attempt / Timestamp / Outcome / Retry-After / X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset / Details.
- Uses `MaxNetworkRetries=0` so raw 429 responses surface directly.

"Developer Tools" nav group added to `MainLayout.razor` and `samples/README.md` updated with usage notes.

## Test results

```
Test Run Successful.
Total tests: 59 — Passed: 59 — Failed: 0 — Skipped: 0
```

## Checklist

- [x] All existing tests pass
- [x] 16 new tests added and passing
- [x] Sample app builds successfully
- [x] `X-RateLimit-Test` blocked outside sandbox
- [x] Per-request headers preserved on every retry attempt
- [x] `samples/README.md` updated
- [x] No new NuGet packages added