### PR TITLE
Add OSS community, support, and security documentation baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Default owners
+* @markheydon
+
+# Core SDK
+/src/ @markheydon
+/tests/ @markheydon
+
+# Sample app
+/samples/ @markheydon
+
+# Repository automation and docs
+/.github/ @markheydon
+/*.md @markheydon
+/plan/ @markheydon
+/adr/ @markheydon

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [markheydon]
+ko_fi: markheydon

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,4 +11,4 @@ contact_links:
     about: Report vulnerabilities privately and review the disclosure policy.
   - name: FreeAgent API Documentation
     url: https://dev.freeagent.com/docs
-    about: Check upstream FreeAgent API behavior and constraints.
+    about: Check upstream FreeAgent API behaviour and constraints.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Support Policy
+    url: https://github.com/markheydon/freeagent-dotnet/blob/main/SUPPORT.md
+    about: Read support routing and expectations before opening an issue.
   - name: Usage Questions and Support
     url: https://github.com/markheydon/freeagent-dotnet/discussions
     about: Ask setup and usage questions, or start a discussion before opening a new issue.
+  - name: Security Vulnerability Reporting
+    url: https://github.com/markheydon/freeagent-dotnet/security/policy
+    about: Report vulnerabilities privately and review the disclosure policy.
   - name: FreeAgent API Documentation
     url: https://dev.freeagent.com/docs
     about: Check upstream FreeAgent API behavior and constraints.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,81 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness towards other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainer via GitHub private channels where available, or by opening a private vulnerability report route under the repository Security tab when safety is a concern.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behaviour deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behaviour. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behaviour.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behaviour, harassment of an individual, or aggression towards or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at:
+
+- https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see:
+
+- https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainer via GitHub private channels where available, or by opening a private vulnerability report route under the repository Security tab when safety is a concern.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported privately to the project maintainer using the dedicated conduct-reporting contact method published by this project. Do not use the repository Security tab or private vulnerability reporting for Code of Conduct reports; those channels are reserved for security vulnerabilities only.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to FreeAgent.NET
+
+Thanks for your interest in contributing to FreeAgent.NET.
+
+This project aims to provide a modern, strongly typed .NET SDK for the FreeAgent REST API with a predictable developer experience.
+
+## Before You Start
+
+- Read [GOALS.md](GOALS.md) for project intent and success criteria.
+- Read [SCOPE.md](SCOPE.md) to confirm your change is in scope.
+- Read [CONVENTIONS.md](CONVENTIONS.md) for architecture and naming conventions.
+- Read [VERSIONING.md](VERSIONING.md) for compatibility and release-stage expectations.
+- For behaviour and design constraints in the sample app, read [.github/copilot-instructions.md](.github/copilot-instructions.md).
+
+## Ways to Contribute
+
+- Report bugs using the bug report template.
+- Propose new capabilities using the feature request template.
+- Improve documentation, tests, and sample coverage.
+- Submit fixes for confirmed defects.
+
+For setup and usage questions, please use [GitHub Discussions](https://github.com/markheydon/freeagent-dotnet/discussions) first.
+
+## Development Setup
+
+Requirements:
+
+- .NET 10 SDK.
+
+Build and test locally:
+
+```bash
+dotnet build
+dotnet test
+```
+
+## Branch and Pull Request Workflow
+
+1. Fork the repository and create a feature branch from `main`.
+2. Keep changes focused and small where practical.
+3. Add or update tests for behavioural changes.
+4. Update docs affected by your change.
+5. Open a pull request using the PR template.
+
+## Pull Request Expectations
+
+- Follow existing coding conventions and project structure.
+- Preserve backwards compatibility unless a breaking change is explicitly discussed.
+- Include clear rationale and scope in the PR description.
+- Ensure CI is green before requesting final review.
+
+## Endpoint and Sample App Sync
+
+The Blazor sample is a living reference of what the SDK implements today.
+
+If you add, remove, or rename SDK endpoints under `src/FreeAgent.Client/Services/`, update `samples/FreeAgent.Client.Sample` in the same PR so the sample remains aligned.
+
+## Testing Guidance
+
+- Prefer unit tests close to changed behaviour.
+- Keep tests deterministic and focused.
+- For endpoint work, add coverage for success and relevant failure pathways.
+
+## Documentation Guidance
+
+- Use UK English spelling in all documentation and comments.
+- Keep README and plan documents aligned with implemented behaviour, not aspirational behaviour.
+
+## Security
+
+Do not disclose security vulnerabilities in public issues or discussions.
+
+Use the process in [SECURITY.md](SECURITY.md).
+
+## Code of Conduct
+
+By participating in this project, you agree to follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Questions and Support
+
+See [SUPPORT.md](SUPPORT.md) for support routes and expectations.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,25 @@ Requirements:
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome.
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+
+By participating in this project, you agree to follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Support
+
+Use [GitHub Discussions](https://github.com/markheydon/freeagent-dotnet/discussions) for setup and usage questions.
+
+For confirmed bugs and actionable work items, use the repository issue templates.
+
+See [SUPPORT.md](SUPPORT.md) for support routing and expectations.
+
+## Security
+
+Do not disclose vulnerabilities in public issues or discussions.
+
+See [SECURITY.md](SECURITY.md) for private vulnerability reporting and disclosure process.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities via public GitHub issues or discussions.
+
+Use GitHub's private vulnerability reporting flow for this repository:
+
+1. Go to the repository Security tab.
+2. Select Report a vulnerability.
+3. Submit a private report with reproduction details, impact, and any suggested remediation.
+
+If you cannot use GitHub private reporting, open a discussion first only for non-sensitive questions and avoid sharing exploit details.
+
+## What to Include
+
+Please include as much of the following as possible:
+
+- A clear description of the vulnerability.
+- Affected package and version.
+- Reproduction steps or proof of concept.
+- Potential impact and attack surface.
+- Any suggested fix or mitigation.
+
+## Response Expectations
+
+Best-effort targets:
+
+- Initial acknowledgement: within 5 working days.
+- Triage outcome: within 10 working days when reproducible details are provided.
+- Ongoing updates: provided at key milestones until resolution.
+
+Timelines may vary depending on severity and maintainer availability.
+
+## Disclosure Process
+
+- Reports are reviewed privately.
+- Remediation is prepared and validated.
+- A fix is released.
+- Public disclosure follows coordinated timing once users can reasonably patch.
+
+## Supported Versions
+
+This project is currently in prerelease stages. Security fixes are applied on a best-effort basis to the latest prerelease line.
+
+For release-stage policy and compatibility expectations, see [VERSIONING.md](VERSIONING.md).
+
+## Scope
+
+This policy covers:
+
+- The FreeAgent .NET SDK code in this repository.
+- Published NuGet packages produced from this repository.
+
+Third-party services, upstream API behaviour, and local deployment issues outside this repository are out of scope.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,44 @@
+# Support
+
+## Getting Help
+
+Use [GitHub Discussions](https://github.com/markheydon/freeagent-dotnet/discussions) as the primary channel for:
+
+- Setup and usage questions.
+- Troubleshooting help.
+- Design and API usage discussion.
+- General project feedback.
+
+## When to Open an Issue
+
+Open a GitHub issue only for confirmed defects, actionable feature requests, or maintenance tasks.
+
+Use the repository templates:
+
+- Bug report.
+- Feature request.
+- Chore request.
+- Story request.
+
+## Before Opening a New Thread
+
+- Check [README.md](README.md) and [VERSIONING.md](VERSIONING.md).
+- Search existing issues and discussions for similar topics.
+- For API behaviour questions, check the upstream [FreeAgent API documentation](https://dev.freeagent.com/docs).
+
+## Security Issues
+
+Do not post security vulnerabilities in public threads.
+
+Follow [SECURITY.md](SECURITY.md) for private disclosure.
+
+## Response Expectations
+
+Support is provided on a best-effort basis.
+
+Please provide:
+
+- SDK version.
+- Runtime and OS details.
+- Minimal reproduction where possible.
+- Relevant logs or error messages (with secrets removed).


### PR DESCRIPTION
## Summary
Adds a lightweight open-source documentation baseline and related GitHub metadata for the current alpha stage.

## Changes
- Add `CONTRIBUTING.md` with contribution workflow, expectations, and project-specific guidance.
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1).
- Add `SECURITY.md` with private vulnerability reporting and disclosure guidance.
- Add `SUPPORT.md` with Discussions-first support routing.
- Add `.github/CODEOWNERS` for ownership mapping (future-ready; optional enforcement).
- Add `.github/FUNDING.yml` with sponsor links.
- Update `README.md` to link contributing, support, and security guidance.
- Update `.github/ISSUE_TEMPLATE/config.yml` contact links for support and security routes.

## Notes
- No runtime code changes.
- No package/dependency changes.
- Documentation and repository configuration only.